### PR TITLE
Switch to TCPDF and guard missing agreement templates

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -11,6 +11,7 @@ class GMS_Admin {
     public function __construct() {
         add_action('admin_menu', array($this, 'addMenuPages'));
         add_action('admin_init', array($this, 'registerSettings'));
+        add_action('admin_init', array($this, 'ensureAgreementTemplateDefault'));
         add_action('admin_post_gms_save_template', array($this, 'saveTemplate'));
     }
     
@@ -68,6 +69,14 @@ class GMS_Admin {
         register_setting('gms_settings', 'gms_voipms_did');
         register_setting('gms_settings', 'gms_company_name');
         register_setting('gms_settings', 'gms_company_logo');
+    }
+
+    public function ensureAgreementTemplateDefault() {
+        $template = get_option('gms_agreement_template', '');
+
+        if (!is_string($template) || trim($template) === '') {
+            update_option('gms_agreement_template', $this->getDefaultAgreementTemplate());
+        }
     }
     
     public function templatesPage() {

--- a/includes/class-guest-portal.php
+++ b/includes/class-guest-portal.php
@@ -47,15 +47,20 @@ class GMS_Guest_Portal {
         $primary_color = get_option('gms_portal_primary_color', '#0073aa');
         $secondary_color = get_option('gms_portal_secondary_color', '#005a87');
         
-        $agreement_template = get_option('gms_agreement_template');
-        
+        $agreement_template = get_option('gms_agreement_template', '');
+
+        if (!is_string($agreement_template) || trim($agreement_template) === '') {
+            self::displayError(__('The agreement template is not configured. Please contact the property manager.', 'gms'));
+            return;
+        }
+
         // Replace template variables
         $agreement_display = str_replace(
-            ['{guest_name}', '{guest_email}', '{guest_phone}', '{property_name}', '{booking_reference}', 
+            ['{guest_name}', '{guest_email}', '{guest_phone}', '{property_name}', '{booking_reference}',
              '{checkin_date}', '{checkout_date}', '{checkin_time}', '{checkout_time}', '{company_name}'],
-            [$reservation['guest_name'], $reservation['guest_email'], $reservation['guest_phone'], 
+            [$reservation['guest_name'], $reservation['guest_email'], $reservation['guest_phone'],
              $reservation['property_name'], $reservation['booking_reference'],
-             date('F j, Y', strtotime($reservation['checkin_date'])), 
+             date('F j, Y', strtotime($reservation['checkin_date'])),
              date('F j, Y', strtotime($reservation['checkout_date'])),
              $reservation['checkin_time'] ?? '3:00 PM', $reservation['checkout_time'] ?? '11:00 AM',
              $company_name],
@@ -1084,8 +1089,12 @@ class GMS_Guest_Portal {
             wp_send_json_error('Agreement already signed');
         }
         
-        $agreement_text = get_option('gms_agreement_template');
-        
+        $agreement_text = get_option('gms_agreement_template', '');
+
+        if (!is_string($agreement_text) || trim($agreement_text) === '') {
+            wp_send_json_error(__('The agreement template is not configured. Please contact the property manager.', 'gms'));
+        }
+
         $agreement_data = array(
             'reservation_id' => $reservation_id,
             'guest_id' => $reservation['guest_id'],


### PR DESCRIPTION
## Summary
- load the bundled TCPDF library and update PDF generation to use it instead of the missing mPDF dependency
- guard agreement template usage throughout the handler and guest portal so requests fail fast when the option is empty
- seed the default agreement template from the admin bootstrap when no value has been saved

## Testing
- php -l includes/class-agreement-handler.php
- php -l includes/class-guest-portal.php
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d85f3c42e08324a71c148e40a23482