### PR TITLE
Create dedicated dashboard experience for guest management

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -68,9 +68,156 @@ class GMS_Admin {
     }
     
     public function add_admin_menu() {
-        add_menu_page('Guest Management', 'Guest Management', 'manage_options', 'guest-management-dashboard', [$this, 'render_reservations_page'], 'dashicons-businessperson', 25);
-        add_submenu_page('guest-management-dashboard', 'Reservations', 'Reservations', 'manage_options', 'guest-management-dashboard', [$this, 'render_reservations_page']);
-        // Add other pages like Guests, Settings, etc., here if needed.
+        add_menu_page(
+            'Guest Management',
+            'Guest Management',
+            'manage_options',
+            'guest-management-dashboard',
+            [$this, 'render_dashboard_page'],
+            'dashicons-businessperson',
+            25
+        );
+
+        add_submenu_page(
+            'guest-management-dashboard',
+            'Dashboard',
+            'Dashboard',
+            'manage_options',
+            'guest-management-dashboard',
+            [$this, 'render_dashboard_page']
+        );
+
+        add_submenu_page(
+            'guest-management-dashboard',
+            'Reservations',
+            'Reservations',
+            'manage_options',
+            'guest-management-reservations',
+            [$this, 'render_reservations_page']
+        );
+
+        add_submenu_page(
+            'guest-management-dashboard',
+            'Guests',
+            'Guests',
+            'manage_options',
+            'guest-management-guests',
+            [$this, 'render_guests_page']
+        );
+
+        add_submenu_page(
+            'guest-management-dashboard',
+            'Communications & Logs',
+            'Communications/Logs',
+            'manage_options',
+            'guest-management-communications',
+            [$this, 'render_communications_page']
+        );
+
+        add_submenu_page(
+            'guest-management-dashboard',
+            'Templates',
+            'Templates',
+            'manage_options',
+            'guest-management-templates',
+            [$this, 'render_templates_page']
+        );
+
+        add_submenu_page(
+            'guest-management-dashboard',
+            'Settings',
+            'Settings',
+            'manage_options',
+            'guest-management-settings',
+            [$this, 'render_settings_page']
+        );
+    }
+
+    public function render_dashboard_page() {
+        $total_reservations = GMS_Database::get_record_count('reservations');
+        $total_guests = GMS_Database::get_record_count('guests');
+
+        $upcoming_checkins = gms_get_upcoming_checkins(7);
+        $pending_checkins = gms_get_pending_checkins();
+        $recent_reservations = GMS_Database::get_reservations(5, 1);
+
+        $upcoming_count = is_array($upcoming_checkins) ? count($upcoming_checkins) : 0;
+        $pending_count = is_array($pending_checkins) ? count($pending_checkins) : 0;
+
+        ?>
+        <div class="wrap gms-dashboard">
+            <h1 class="wp-heading-inline"><?php esc_html_e('Guest Management Dashboard', 'guest-management-system'); ?></h1>
+            <hr class="wp-header-end">
+
+            <div class="gms-dashboard-stats">
+                <div class="gms-stat-box">
+                    <h3><?php echo esc_html(number_format_i18n($total_reservations)); ?></h3>
+                    <p><?php esc_html_e('Total Reservations', 'guest-management-system'); ?></p>
+                </div>
+                <div class="gms-stat-box">
+                    <h3><?php echo esc_html(number_format_i18n($upcoming_count)); ?></h3>
+                    <p><?php esc_html_e('Upcoming Check-ins (7 Days)', 'guest-management-system'); ?></p>
+                </div>
+                <div class="gms-stat-box">
+                    <h3><?php echo esc_html(number_format_i18n($pending_count)); ?></h3>
+                    <p><?php esc_html_e('Pending Check-ins', 'guest-management-system'); ?></p>
+                </div>
+                <div class="gms-stat-box">
+                    <h3><?php echo esc_html(number_format_i18n($total_guests)); ?></h3>
+                    <p><?php esc_html_e('Total Guests', 'guest-management-system'); ?></p>
+                </div>
+            </div>
+
+            <div class="gms-recent-reservations">
+                <h2><?php esc_html_e('Recent Reservations', 'guest-management-system'); ?></h2>
+                <?php if (!empty($recent_reservations)) : ?>
+                    <table class="widefat fixed striped">
+                        <thead>
+                            <tr>
+                                <th><?php esc_html_e('Guest', 'guest-management-system'); ?></th>
+                                <th><?php esc_html_e('Property', 'guest-management-system'); ?></th>
+                                <th><?php esc_html_e('Check-in', 'guest-management-system'); ?></th>
+                                <th><?php esc_html_e('Status', 'guest-management-system'); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($recent_reservations as $reservation) :
+                                $status = isset($reservation['status']) ? $reservation['status'] : '';
+                                $status_slug = $status ? strtolower(str_replace([' ', '_'], '-', $status)) : 'default';
+                                $checkin_display = !empty($reservation['checkin_date'])
+                                    ? gms_format_datetime($reservation['checkin_date'])
+                                    : __('—', 'guest-management-system');
+                                ?>
+                                <tr>
+                                    <td><?php echo esc_html($reservation['guest_name'] ?? __('Unknown Guest', 'guest-management-system')); ?></td>
+                                    <td><?php echo esc_html($reservation['property_name'] ?? __('N/A', 'guest-management-system')); ?></td>
+                                    <td><?php echo esc_html($checkin_display); ?></td>
+                                    <td>
+                                        <?php if ($status) : ?>
+                                            <span class="status-badge status-<?php echo esc_attr($status_slug); ?>"><?php echo esc_html(ucwords(str_replace('_', ' ', $status))); ?></span>
+                                        <?php else : ?>
+                                            <span class="status-badge status-default"><?php esc_html_e('Unknown', 'guest-management-system'); ?></span>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                <?php else : ?>
+                    <p><?php esc_html_e('No recent reservations found.', 'guest-management-system'); ?></p>
+                <?php endif; ?>
+            </div>
+
+            <div class="gms-quick-actions">
+                <h2><?php esc_html_e('Quick Actions', 'guest-management-system'); ?></h2>
+                <a class="button button-primary" href="<?php echo esc_url(admin_url('admin.php?page=guest-management-reservations')); ?>"><?php esc_html_e('Manage Reservations', 'guest-management-system'); ?></a>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=guest-management-guests')); ?>"><?php esc_html_e('View Guests', 'guest-management-system'); ?></a>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=guest-management-communications')); ?>"><?php esc_html_e('Communications & Logs', 'guest-management-system'); ?></a>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=guest-management-templates')); ?>"><?php esc_html_e('Edit Templates', 'guest-management-system'); ?></a>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=guest-management-settings')); ?>"><?php esc_html_e('Open Settings', 'guest-management-system'); ?></a>
+            </div>
+        </div>
+        <?php
     }
     
     public function render_reservations_page() {
@@ -84,6 +231,46 @@ class GMS_Admin {
             <form method="post">
                 <?php $reservations_table->display(); ?>
             </form>
+        </div>
+        <?php
+    }
+
+    public function render_guests_page() {
+        ?>
+        <div class="wrap">
+            <h1 class="wp-heading-inline"><?php esc_html_e('Guests', 'guest-management-system'); ?></h1>
+            <hr class="wp-header-end">
+            <p><?php esc_html_e('Manage guest records, contact information, and stay history from this section.', 'guest-management-system'); ?></p>
+        </div>
+        <?php
+    }
+
+    public function render_communications_page() {
+        ?>
+        <div class="wrap">
+            <h1 class="wp-heading-inline"><?php esc_html_e('Communications & Logs', 'guest-management-system'); ?></h1>
+            <hr class="wp-header-end">
+            <p><?php esc_html_e('Review automated emails, SMS activity, and other communication logs here.', 'guest-management-system'); ?></p>
+        </div>
+        <?php
+    }
+
+    public function render_templates_page() {
+        ?>
+        <div class="wrap">
+            <h1 class="wp-heading-inline"><?php esc_html_e('Templates', 'guest-management-system'); ?></h1>
+            <hr class="wp-header-end">
+            <p><?php esc_html_e('Customize notification and agreement templates used throughout the guest journey.', 'guest-management-system'); ?></p>
+        </div>
+        <?php
+    }
+
+    public function render_settings_page() {
+        ?>
+        <div class="wrap">
+            <h1 class="wp-heading-inline"><?php esc_html_e('Settings', 'guest-management-system'); ?></h1>
+            <hr class="wp-header-end">
+            <p><?php esc_html_e('Configure integrations, automation rules, and other plugin options.', 'guest-management-system'); ?></p>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- replace the top-level Guest Management menu with a purpose-built dashboard view that surfaces key stats, recent reservations, and quick actions styled for the existing admin CSS
- wire up reservations, guests, communications/logs, templates, and settings submenu entries so each screen has a dedicated render method for future enhancements

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d8a07662a8832498a8b9b1149c3c25