### PR TITLE
Add tabbed settings page with registered options

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -10,16 +10,66 @@
 
     $(document).ready(function() {
         
-        // Tab switching functionality
+        // Tab switching functionality for hash-based tabs only
         $('.nav-tab').on('click', function(e) {
-            e.preventDefault();
             var target = $(this).attr('href');
-            
-            $('.nav-tab').removeClass('nav-tab-active');
-            $(this).addClass('nav-tab-active');
-            
-            $('.gms-tab-content').removeClass('active');
-            $(target).addClass('active');
+            if (target && target.charAt(0) === '#') {
+                e.preventDefault();
+
+                $('.nav-tab').removeClass('nav-tab-active');
+                $(this).addClass('nav-tab-active');
+
+                $('.gms-tab-content').removeClass('active');
+                $(target).addClass('active');
+            }
+        });
+
+        // Media uploader for logo selection
+        $('.gms-upload-logo').on('click', function(e) {
+            e.preventDefault();
+
+            var button = $(this);
+            var field = $('#' + button.data('target'));
+            var preview = $('#' + button.data('preview'));
+
+            var frame = wp.media({
+                title: button.data('title') || 'Select Logo',
+                button: {
+                    text: button.data('button-text') || 'Use this logo'
+                },
+                multiple: false,
+                library: {
+                    type: ['image']
+                }
+            });
+
+            frame.on('select', function() {
+                var attachment = frame.state().get('selection').first().toJSON();
+                field.val(attachment.url).trigger('change');
+                var image = $('<img />', {
+                    src: attachment.url,
+                    alt: attachment.alt || '',
+                    css: {
+                        maxWidth: '200px',
+                        height: 'auto',
+                        marginTop: '10px'
+                    }
+                });
+                preview.html(image).show();
+            });
+
+            frame.open();
+        });
+
+        $('.gms-remove-logo').on('click', function(e) {
+            e.preventDefault();
+
+            var button = $(this);
+            var field = $('#' + button.data('target'));
+            var preview = $('#' + button.data('preview'));
+
+            field.val('').trigger('change');
+            preview.empty().hide();
         });
 
         // Test SMS functionality


### PR DESCRIPTION
## Summary
- register plugin settings with appropriate sanitization and section/field callbacks
- implement a tabbed admin settings page leveraging the WordPress Settings API and contextual template token help
- update admin JavaScript to support media-based logo uploads while preserving existing tab behaviour

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d8a149f69c8324b513b1ae3869704e