### PR TITLE
Add guest upsert helper and reservation backfill

### DIFF
--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -53,7 +53,9 @@ class GuestManagementSystem {
         new GMS_SMS_Handler();
         new GMS_Stripe_Integration();
         new GMS_Agreement_Handler(); // Initialize the new agreement handler
-        
+
+        GMS_Database::maybeScheduleGuestBackfill();
+
         // Add custom user role for guests
         $this->addGuestRole();
         

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1123,8 +1123,23 @@ class GMS_Admin {
                 $errors[] = __('Please enter a valid email address.', 'guest-management-system');
             }
 
+            $guest_id = 0;
+
+            if (empty($errors)) {
+                $guest_id = GMS_Database::upsert_guest(array(
+                    'name' => $form_values['guest_name'],
+                    'email' => $form_values['guest_email'],
+                    'phone' => $form_values['guest_phone'],
+                ));
+
+                if (!$guest_id) {
+                    $errors[] = __('Unable to save guest details. Please try again.', 'guest-management-system');
+                }
+            }
+
             if (empty($errors)) {
                 $reservation_data = array(
+                    'guest_id' => $guest_id,
                     'guest_name' => $form_values['guest_name'],
                     'guest_email' => $form_values['guest_email'],
                     'guest_phone' => $form_values['guest_phone'],

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -96,12 +96,16 @@ function gms_update_reservation_status($reservation_id, $status) {
  */
 function gms_get_guest_user($reservation_id) {
     $reservation = GMS_Database::getReservationById($reservation_id);
-    
+
     if (!$reservation) {
         return false;
     }
-    
-    return get_user_by('id', $reservation['guest_id']);
+
+    if (empty($reservation['guest_id'])) {
+        return false;
+    }
+
+    return GMS_Database::get_guest_by_id($reservation['guest_id']);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a database-level guest upsert helper and return real guest IDs when reservations are created
- store the guest identifier on reservations, schedule a backfill for historical rows, and surface guest records in admin lists
- expose guest lookup utilities for existing integrations that relied on WordPress user IDs

## Testing
- php -l guest-management-system.php
- php -l includes/class-admin.php
- php -l includes/class-database.php
- php -l includes/class-webhook-handler.php
- php -l includes/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d8aa35c49483248c664ce08ba74622