### PR TITLE
Align templates submenu with templates settings

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1312,11 +1312,29 @@ class GMS_Admin {
     }
 
     public function render_templates_page() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        if (isset($_GET['settings-updated'])) {
+            add_settings_error('gms_settings_messages', 'gms_settings_updated', __('Settings saved.', 'guest-management-system'), 'updated');
+        }
+
         ?>
-        <div class="wrap">
+        <div class="wrap gms-settings">
             <h1 class="wp-heading-inline"><?php esc_html_e('Templates', 'guest-management-system'); ?></h1>
             <hr class="wp-header-end">
             <p><?php esc_html_e('Customize notification and agreement templates used throughout the guest journey.', 'guest-management-system'); ?></p>
+
+            <?php settings_errors('gms_settings_messages'); ?>
+
+            <form action="options.php" method="post">
+                <?php
+                settings_fields('gms_settings_templates');
+                do_settings_sections('gms_settings_templates');
+                submit_button();
+                ?>
+            </form>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- reuse the `gms_settings_templates` registration when rendering the Templates admin submenu
- add a nonce-protected `options.php` form so updates mirror the Templates settings tab
- ensure the template token help guidance displays on the submenu page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8ac578c0c83248f2494c7f1d24a7e