### PR TITLE
Add guest portal column and inline reservation editor

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -26,8 +26,435 @@
         return '';
     }
 
+    function getString(key, fallback) {
+        if (adminConfig.strings && adminConfig.strings[key]) {
+            return adminConfig.strings[key];
+        }
+
+        return fallback;
+    }
+
+    var reservationCache = {};
+
+    function copyTextToClipboard(text) {
+        var deferred = $.Deferred();
+
+        if (!text) {
+            deferred.resolve(false);
+            return deferred.promise();
+        }
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function() {
+                deferred.resolve(true);
+            }).catch(function() {
+                fallbackCopyText(text, deferred);
+            });
+        } else {
+            fallbackCopyText(text, deferred);
+        }
+
+        return deferred.promise();
+    }
+
+    function fallbackCopyText(text, deferred) {
+        var $helper = $('<textarea>', {
+            text: text,
+            readonly: true,
+            class: 'gms-clipboard-helper'
+        }).css({
+            position: 'absolute',
+            left: '-9999px',
+            top: '0',
+            opacity: '0'
+        });
+
+        $('body').append($helper);
+        $helper[0].focus();
+        $helper[0].select();
+
+        var successful = false;
+
+        try {
+            successful = document.execCommand('copy');
+        } catch (err) {
+            successful = false;
+        }
+
+        $helper.remove();
+        deferred.resolve(successful);
+    }
+
+    function showCopyFeedback($element, message, isError) {
+        if (!$element || !$element.length) {
+            return;
+        }
+
+        var originalText = $element.data('original-text');
+        if (typeof originalText === 'undefined') {
+            originalText = $.trim($element.text());
+            $element.data('original-text', originalText);
+        }
+
+        var originalAria = $element.data('original-aria-label');
+        if (typeof originalAria === 'undefined') {
+            originalAria = $element.attr('aria-label') || '';
+            $element.data('original-aria-label', originalAria);
+        }
+
+        $element.toggleClass('gms-copy-error', !!isError);
+        $element.toggleClass('gms-copy-success', !isError);
+        $element.text(message);
+        $element.attr('aria-label', message);
+
+        setTimeout(function() {
+            $element.removeClass('gms-copy-success gms-copy-error');
+            $element.text(originalText);
+
+            if (originalAria) {
+                $element.attr('aria-label', originalAria);
+            } else {
+                $element.removeAttr('aria-label');
+            }
+        }, 2000);
+    }
+
+    function getColumnCount($row) {
+        var count = $row.children('th, td').length;
+
+        if (!count) {
+            count = $row.closest('table').find('thead th').length;
+        }
+
+        return count || 1;
+    }
+
+    function createField(reservation, name, label, type) {
+        var fieldId = 'gms-reservation-' + name + '-' + (reservation.id || 'new');
+        var $wrapper = $('<div/>', { 'class': 'gms-reservation-form__field' });
+        var $label = $('<label/>', { 'for': fieldId, text: label });
+        var $input = $('<input/>', {
+            type: type || 'text',
+            id: fieldId,
+            name: name,
+            'class': 'regular-text'
+        });
+
+        if (reservation && reservation[name] !== undefined && reservation[name] !== null) {
+            $input.val(reservation[name]);
+        }
+
+        $wrapper.append($label).append($input);
+
+        return $wrapper;
+    }
+
+    function buildReservationForm(reservation) {
+        var $form = $('<form/>', {
+            'class': 'gms-reservation-form',
+            'data-reservation-id': reservation.id || ''
+        });
+
+        var $grid = $('<div/>', { 'class': 'gms-reservation-form__grid' });
+
+        $grid.append(createField(reservation, 'guest_name', getString('guestName', 'Guest Name')));
+        $grid.append(createField(reservation, 'guest_email', getString('guestEmail', 'Guest Email'), 'email'));
+        $grid.append(createField(reservation, 'guest_phone', getString('guestPhone', 'Guest Phone'), 'tel'));
+        $grid.append(createField(reservation, 'property_name', getString('propertyName', 'Property Name')));
+        $grid.append(createField(reservation, 'booking_reference', getString('bookingReference', 'Booking Reference')));
+        $grid.append(createField(reservation, 'checkin_date', getString('checkinDate', 'Check-in Date')));
+        $grid.append(createField(reservation, 'checkout_date', getString('checkoutDate', 'Check-out Date')));
+        $grid.append(createField(reservation, 'status', getString('statusLabel', 'Status')));
+
+        $form.append($grid);
+
+        var $feedback = $('<div/>', {
+            'class': 'gms-reservation-feedback',
+            'aria-live': 'polite'
+        });
+
+        $form.append($feedback);
+
+        var $actions = $('<p/>', { 'class': 'submit' });
+        var $saveButton = $('<button/>', {
+            type: 'submit',
+            'class': 'button button-primary',
+            text: getString('saveChanges', 'Save Changes')
+        });
+        var $cancelButton = $('<button/>', {
+            type: 'button',
+            'class': 'button button-secondary gms-reservation-cancel',
+            text: getString('cancel', 'Cancel')
+        });
+
+        $actions.append($saveButton).append(' ').append($cancelButton);
+        $form.append($actions);
+
+        return $form;
+    }
+
+    function populateReservationForm($form, reservation) {
+        if (!$form || !$form.length || !reservation) {
+            return;
+        }
+
+        $.each(reservation, function(key, value) {
+            var $field = $form.find('[name="' + key + '"]');
+
+            if ($field.length) {
+                $field.val(value == null ? '' : value);
+            }
+        });
+    }
+
+    function renderEditorContent($editorRow, reservationId, reservation) {
+        if (!$editorRow || !$editorRow.length) {
+            return;
+        }
+
+        var $cell = $editorRow.find('td');
+        $cell.empty();
+
+        var $container = $('<div/>', { 'class': 'gms-reservation-editor__container' });
+        var titleText = getString('editReservationTitle', 'Edit Reservation');
+
+        if (reservation && reservation.id) {
+            titleText += ' #' + reservation.id;
+        }
+
+        var $title = $('<h3/>', { 'class': 'gms-reservation-editor__title' }).text(titleText);
+        $container.append($title);
+
+        var $form = buildReservationForm(reservation || {});
+        $form.attr('data-reservation-id', reservationId || '');
+        populateReservationForm($form, reservation || {});
+        $container.append($form);
+
+        $cell.append($container);
+        $editorRow.removeClass('is-loading');
+    }
+
+    function fetchReservation(reservationId) {
+        return $.ajax({
+            url: ajaxurl,
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                action: 'gms_get_reservation',
+                reservation_id: reservationId,
+                nonce: getNonce()
+            }
+        });
+    }
+
+    function handleReservationError($editorRow, message) {
+        if (!$editorRow || !$editorRow.length) {
+            return;
+        }
+
+        var $cell = $editorRow.find('td');
+        $cell.empty();
+
+        var $container = $('<div/>', { 'class': 'gms-reservation-editor__container' });
+        $container.append($('<p/>', { 'class': 'gms-reservation-editor__error' }).text(message));
+        $cell.append($container);
+
+        setTimeout(function() {
+            var $triggerRow = $editorRow.prev('tr');
+            $editorRow.remove();
+
+            if ($triggerRow && $triggerRow.length) {
+                $triggerRow.find('.gms-reservation-toggle').attr('aria-expanded', 'false').removeClass('is-active');
+            }
+        }, 2500);
+    }
+
+    function updateReservationRow($row, display) {
+        if (!$row || !$row.length || !display) {
+            return;
+        }
+
+        $.each(display, function(columnKey, value) {
+            if (columnKey === 'cb') {
+                return;
+            }
+
+            var $cell = $row.find('.column-' + columnKey);
+
+            if ($cell.length) {
+                $cell.html(value);
+            }
+        });
+    }
+
     $(document).ready(function() {
-        
+
+        $(document).on('click', '.gms-open-portal', function(e) {
+            e.preventDefault();
+
+            var $link = $(this);
+            var url = $link.attr('href') || $link.data('copy-url');
+
+            if (!url) {
+                return;
+            }
+
+            var newWindow = window.open(url, '_blank', 'noopener');
+
+            if (newWindow) {
+                newWindow.opener = null;
+            }
+
+            var copyValue = $link.data('copy-url') || url;
+
+            copyTextToClipboard(copyValue).done(function(success) {
+                var message = success
+                    ? getString('copySuccess', 'Link copied to clipboard.')
+                    : getString('copyError', 'Unable to copy link.');
+
+                showCopyFeedback($link, message, !success);
+            });
+        });
+
+        $(document).on('click', '.gms-reservation-toggle', function(e) {
+            e.preventDefault();
+
+            var $button = $(this);
+            var reservationId = parseInt($button.data('reservation-id'), 10);
+
+            if (!reservationId) {
+                return;
+            }
+
+            var $row = $button.closest('tr');
+            var $existing = $row.next('.gms-reservation-editor');
+
+            if ($existing.length && !$existing.hasClass('is-loading')) {
+                $existing.remove();
+                $button.attr('aria-expanded', 'false').removeClass('is-active');
+                return;
+            }
+
+            if ($existing.length) {
+                $existing.remove();
+            }
+
+            var columnCount = getColumnCount($row);
+            var $editorRow = $('<tr class="gms-reservation-editor is-loading"></tr>');
+            var $cell = $('<td/>', { colspan: columnCount });
+            var $container = $('<div/>', { 'class': 'gms-reservation-editor__container' });
+            $container.append($('<p/>', { 'class': 'gms-reservation-editor__loading' }).text(getString('loadingReservation', 'Loading reservation…')));
+            $cell.append($container);
+            $editorRow.append($cell);
+            $row.after($editorRow);
+
+            $button.attr('aria-expanded', 'true').addClass('is-active');
+
+            var cached = reservationCache[reservationId];
+
+            if (cached && cached.reservation) {
+                renderEditorContent($editorRow, reservationId, cached.reservation);
+                return;
+            }
+
+            fetchReservation(reservationId).done(function(response) {
+                if (response && response.success && response.data && response.data.reservation) {
+                    reservationCache[reservationId] = response.data;
+                    renderEditorContent($editorRow, reservationId, response.data.reservation);
+                } else {
+                    handleReservationError($editorRow, getString('loadError', 'Unable to load reservation details. Please try again.'));
+                }
+            }).fail(function() {
+                handleReservationError($editorRow, getString('loadError', 'Unable to load reservation details. Please try again.'));
+            });
+        });
+
+        $(document).on('click', '.gms-reservation-cancel', function(e) {
+            e.preventDefault();
+
+            var $editorRow = $(this).closest('tr.gms-reservation-editor');
+            var $triggerRow = $editorRow.prev('tr');
+
+            $editorRow.remove();
+
+            if ($triggerRow && $triggerRow.length) {
+                $triggerRow.find('.gms-reservation-toggle').attr('aria-expanded', 'false').removeClass('is-active');
+            }
+        });
+
+        $(document).on('submit', '.gms-reservation-form', function(e) {
+            e.preventDefault();
+
+            var $form = $(this);
+            var reservationId = parseInt($form.data('reservation-id'), 10);
+
+            if (!reservationId) {
+                return;
+            }
+
+            var $editorRow = $form.closest('tr.gms-reservation-editor');
+            var $row = $editorRow.prev('tr');
+            var $submitButton = $form.find('button[type="submit"]');
+            var originalSubmitText = $submitButton.text();
+            var $feedback = $form.find('.gms-reservation-feedback');
+
+            $feedback.removeClass('is-error is-success').text('');
+            $submitButton.prop('disabled', true).text(getString('saving', 'Saving…'));
+
+            var formData = {};
+
+            $.each($form.serializeArray(), function(_, field) {
+                if (field.name) {
+                    formData[field.name] = field.value;
+                }
+            });
+
+            $.ajax({
+                url: ajaxurl,
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'gms_update_reservation',
+                    reservation_id: reservationId,
+                    reservation: formData,
+                    nonce: getNonce()
+                }
+            }).done(function(response) {
+                if (!response || !response.success || !response.data) {
+                    var genericError = getString('updateError', 'Unable to save the reservation. Please try again.');
+                    var message = response && response.data ? response.data : genericError;
+                    $feedback.addClass('is-error').text(message);
+                    return;
+                }
+
+                var payload = response.data;
+                reservationCache[reservationId] = payload;
+
+                populateReservationForm($form, payload.reservation || {});
+                updateReservationRow($row, payload.display);
+
+                var successMessage = getString('updateSuccess', 'Reservation updated.');
+                $feedback.addClass('is-success').text(successMessage);
+
+                var $newToggle = $row.find('.column-booking_reference .gms-reservation-toggle');
+
+                if ($newToggle.length) {
+                    $newToggle.attr('aria-expanded', 'true').addClass('is-active');
+                }
+            }).fail(function(xhr) {
+                var genericError = getString('updateError', 'Unable to save the reservation. Please try again.');
+                var message = genericError;
+
+                if (xhr && xhr.responseJSON && xhr.responseJSON.data) {
+                    message = xhr.responseJSON.data;
+                }
+
+                $feedback.addClass('is-error').text(message);
+            }).always(function() {
+                $submitButton.prop('disabled', false).text(originalSubmitText);
+            });
+        });
+
         // Tab switching functionality for hash-based tabs only
         $('.nav-tab').on('click', function(e) {
             var target = $(this).attr('href');

--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -203,6 +203,26 @@ class GuestManagementSystem {
                 'gms_admin_nonce' => wp_create_nonce('gms_admin_nonce'),
                 'gms_webhook_url' => $webhook_base,
                 'webhookUrls' => $webhook_urls,
+                'strings' => [
+                    'loadingReservation' => __('Loading reservation…', 'guest-management-system'),
+                    'editReservationTitle' => __('Edit Reservation', 'guest-management-system'),
+                    'saveChanges' => __('Save Changes', 'guest-management-system'),
+                    'saving' => __('Saving…', 'guest-management-system'),
+                    'cancel' => __('Cancel', 'guest-management-system'),
+                    'updateSuccess' => __('Reservation updated.', 'guest-management-system'),
+                    'updateError' => __('Unable to save the reservation. Please try again.', 'guest-management-system'),
+                    'loadError' => __('Unable to load reservation details. Please try again.', 'guest-management-system'),
+                    'copySuccess' => __('Portal link copied to clipboard.', 'guest-management-system'),
+                    'copyError' => __('Unable to copy the portal link.', 'guest-management-system'),
+                    'guestName' => __('Guest Name', 'guest-management-system'),
+                    'guestEmail' => __('Guest Email', 'guest-management-system'),
+                    'guestPhone' => __('Guest Phone', 'guest-management-system'),
+                    'propertyName' => __('Property Name', 'guest-management-system'),
+                    'bookingReference' => __('Booking Reference', 'guest-management-system'),
+                    'checkinDate' => __('Check-in Date', 'guest-management-system'),
+                    'checkoutDate' => __('Check-out Date', 'guest-management-system'),
+                    'statusLabel' => __('Status', 'guest-management-system'),
+                ],
             ]
         );
     }


### PR DESCRIPTION
## Summary
- add a Guest Portal column to the reservations table with a shareable link button and make the booking reference cell interactive
- expose AJAX endpoints for fetching and updating reservations and localize supporting UI strings
- extend the admin script with portal link copy helpers and an inline reservation editing workflow

## Testing
- php -l includes/class-admin.php
- php -l guest-management-system.php

------
https://chatgpt.com/codex/tasks/task_e_68d8afb3c3548324be1a6d58f4fea361