### PR TITLE
Ensure Stripe verification request uses JSON encoding

### DIFF
--- a/includes/class-stripe-integration.php
+++ b/includes/class-stripe-integration.php
@@ -53,11 +53,20 @@ class GMS_Stripe_Integration {
             )
         );
         
+        $body_json = wp_json_encode($body_params);
+
+        if (false === $body_json) {
+            error_log('GMS Stripe Error: Unable to encode verification session body.');
+            return false;
+        }
+
         $response = wp_remote_post($endpoint, array(
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->secret_key,
+                'Content-Type' => 'application/json',
             ),
-            'body' => $body_params,
+            'body' => $body_json,
+            'data_format' => 'body',
             'timeout' => 30
         ));
         


### PR DESCRIPTION
## Summary
- JSON-encode verification session payloads before posting to Stripe
- Add Content-Type header and keep booleans intact when sending to Stripe
- Handle JSON encoding failures gracefully to avoid silent errors

## Testing
- Not run (reason: no automated test suite provided)


------
https://chatgpt.com/codex/tasks/task_e_68d9523b90bc8324a1e06526ea015406