### PR TITLE
Fix Stripe verification session request encoding

### DIFF
--- a/includes/class-stripe-integration.php
+++ b/includes/class-stripe-integration.php
@@ -53,19 +53,12 @@ class GMS_Stripe_Integration {
             )
         );
         
-        $body_json = wp_json_encode($body_params);
-
-        if (false === $body_json) {
-            error_log('GMS Stripe Error: Unable to encode verification session body.');
-            return false;
-        }
-
         $response = wp_remote_post($endpoint, array(
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->secret_key,
-                'Content-Type' => 'application/json',
+                'Content-Type' => 'application/x-www-form-urlencoded',
             ),
-            'body' => $body_json,
+            'body' => http_build_query($body_params, '', '&'),
             'data_format' => 'body',
             'timeout' => 30
         ));


### PR DESCRIPTION
## Summary
- send verification session parameters as form-encoded data so Stripe receives nested option values
- update the request headers to advertise application/x-www-form-urlencoded payloads

## Testing
- php -l includes/class-stripe-integration.php

------
https://chatgpt.com/codex/tasks/task_e_68d9590f0e1c8324b49b71cfe2fd0871