### PR TITLE
Send Stripe verification payload as JSON

### DIFF
--- a/includes/class-stripe-integration.php
+++ b/includes/class-stripe-integration.php
@@ -57,10 +57,9 @@ class GMS_Stripe_Integration {
         $response = wp_remote_post($endpoint, array(
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->secret_key,
-                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Content-Type' => 'application/json',
             ),
-            'body' => http_build_query($body_params, '', '&'),
-            'data_format' => 'body',
+            'body' => wp_json_encode($body_params),
             'timeout' => 30
         ));
         


### PR DESCRIPTION
## Summary
- send the Stripe identity verification session request as JSON so boolean options remain intact

## Testing
- php -l includes/class-stripe-integration.php

------
https://chatgpt.com/codex/tasks/task_e_68d95fb001e48324a7b9f01fe631ebbe