### PR TITLE
Use JSON payload for Stripe verification session

### DIFF
--- a/includes/class-stripe-integration.php
+++ b/includes/class-stripe-integration.php
@@ -35,32 +35,50 @@ class GMS_Stripe_Integration {
         
         $endpoint = $this->api_url . '/identity/verification_sessions';
         
-        // BUG FIX: Use a robust array for the body instead of a manual string.
-        // This prevents errors with special characters in reservation data.
+        $metadata = array(
+            'reservation_id' => isset($reservation['id']) ? (string) $reservation['id'] : '',
+            'guest_id' => isset($reservation['guest_id']) ? (string) $reservation['guest_id'] : '',
+            'booking_reference' => isset($reservation['booking_reference']) ? (string) $reservation['booking_reference'] : '',
+        );
+
+        $filtered_metadata = array();
+        foreach ($metadata as $key => $value) {
+            if ($value !== '') {
+                $filtered_metadata[$key] = $value;
+            }
+        }
+
+        $document_options = array(
+            'allowed_types' => array('driving_license', 'passport', 'id_card'),
+            'require_id_number' => true,
+            'require_live_capture' => true,
+            'require_matching_selfie' => true,
+        );
+
         $body_params = array(
             'type' => 'document',
-            'metadata' => array(
-                'reservation_id' => $reservation['id'],
-                'guest_id' => $reservation['guest_id'],
-                'booking_reference' => $reservation['booking_reference']
-            ),
             'options' => array(
-                'document' => array(
-                    'allowed_types' => ['driving_license', 'passport', 'id_card'],
-                    'require_id_number' => true,
-                    'require_live_capture' => true,
-                    'require_matching_selfie' => true
-                )
-            )
+                'document' => $document_options,
+            ),
         );
-        
+
+        if (!empty($filtered_metadata)) {
+            $body_params['metadata'] = $filtered_metadata;
+        }
+
+        $encoded_body = wp_json_encode($body_params);
+
+        if (false === $encoded_body) {
+            error_log('GMS Stripe Error: Failed to encode verification session payload.');
+            return false;
+        }
+
         $response = wp_remote_post($endpoint, array(
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->secret_key,
-                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Content-Type' => 'application/json',
             ),
-            'body' => http_build_query($body_params, '', '&'),
-            'data_format' => 'body',
+            'body' => $encoded_body,
             'timeout' => 30
         ));
         


### PR DESCRIPTION
## Summary
- send the verification session payload to Stripe as JSON so the document options retain their boolean values
- add a guard for failed JSON encoding to prevent fatal errors during session creation
- continue attaching filtered reservation metadata while updating the request headers for the JSON body

## Testing
- php -l includes/class-stripe-integration.php

------
https://chatgpt.com/codex/tasks/task_e_68d95fb001e48324a7b9f01fe631ebbe