### PR TITLE
Add approval-based reservation notifications and statuses

### DIFF
--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -119,7 +119,9 @@ class GuestManagementSystem {
             'gms_email_from_name' => get_option('blogname'),
             'gms_agreement_template' => $this->getDefaultAgreementTemplate(),
             'gms_email_template' => $this->getDefaultEmailTemplate(),
-            'gms_sms_template' => $this->getDefaultSMSTemplate()
+            'gms_sms_template' => $this->getDefaultSMSTemplate(),
+            'gms_approved_email_template' => $this->getDefaultApprovedEmailTemplate(),
+            'gms_approved_sms_template' => $this->getDefaultApprovedSMSTemplate()
         );
         
         foreach ($default_options as $key => $value) {
@@ -233,6 +235,14 @@ class GuestManagementSystem {
     
     private function getDefaultSMSTemplate() {
         return 'Hi {guest_name}! Complete your check-in for {property_name} at {portal_link}. Identity verification and agreement signing are required.';
+    }
+
+    private function getDefaultApprovedEmailTemplate() {
+        return "Hi {guest_name},\n\nGreat news—your reservation for {property_name} has been approved!\n\nYou can now access your guest portal to complete the remaining steps for your stay:\n• Review and sign your guest agreement\n• Upload your identification for verification\n\nGuest Portal: {portal_link}\nCheck-in: {checkin_date} at {checkin_time}\nCheck-out: {checkout_date} at {checkout_time}\nBooking Reference: {booking_reference}\n\nIf you have any questions, reply to this email and our team will be happy to help.\n\nWe look forward to welcoming you,\n{company_name}";
+    }
+
+    private function getDefaultApprovedSMSTemplate() {
+        return 'Your stay at {property_name} is approved! Finish your check-in tasks here: {portal_link} - {company_name}';
     }
 }
 

--- a/includes/class-webhook-handler.php
+++ b/includes/class-webhook-handler.php
@@ -246,18 +246,16 @@ class GMS_Webhook_Handler {
                 'guest_id' => intval($guest_profile['wp_user_id'] ?? 0),
                 'guest_record_id' => intval($guest_profile['guest_record_id']),
                 'platform' => 'booking.com',
-                'webhook_data' => $data
+                'webhook_data' => $data,
+                'status' => 'pending'
             ));
-            
+
             $reservation_id = GMS_Database::createReservation($reservation_data);
-            
+
             if (!$reservation_id) {
                 throw new Exception('Failed to create reservation');
             }
-            
-            // Send notifications
-            $this->sendGuestNotifications($reservation_id);
-            
+
             return array(
                 'success' => true,
                 'message' => 'Booking processed successfully',
@@ -292,17 +290,16 @@ class GMS_Webhook_Handler {
                 'guest_id' => intval($guest_profile['wp_user_id'] ?? 0),
                 'guest_record_id' => intval($guest_profile['guest_record_id']),
                 'platform' => 'airbnb',
-                'webhook_data' => $data
+                'webhook_data' => $data,
+                'status' => 'pending'
             ));
-            
+
             $reservation_id = GMS_Database::createReservation($reservation_data);
-            
+
             if (!$reservation_id) {
                 throw new Exception('Failed to create reservation');
             }
-            
-            $this->sendGuestNotifications($reservation_id);
-            
+
             return array(
                 'success' => true,
                 'message' => 'Airbnb booking processed successfully',
@@ -337,17 +334,16 @@ class GMS_Webhook_Handler {
                 'guest_id' => intval($guest_profile['wp_user_id'] ?? 0),
                 'guest_record_id' => intval($guest_profile['guest_record_id']),
                 'platform' => 'vrbo',
-                'webhook_data' => $data
+                'webhook_data' => $data,
+                'status' => 'pending'
             ));
-            
+
             $reservation_id = GMS_Database::createReservation($reservation_data);
-            
+
             if (!$reservation_id) {
                 throw new Exception('Failed to create reservation');
             }
-            
-            $this->sendGuestNotifications($reservation_id);
-            
+
             return array(
                 'success' => true,
                 'message' => 'VRBO booking processed successfully',
@@ -382,17 +378,16 @@ class GMS_Webhook_Handler {
                 'guest_id' => intval($guest_profile['wp_user_id'] ?? 0),
                 'guest_record_id' => intval($guest_profile['guest_record_id']),
                 'platform' => $platform,
-                'webhook_data' => $data
+                'webhook_data' => $data,
+                'status' => 'pending'
             ));
-            
+
             $reservation_id = GMS_Database::createReservation($reservation_data);
-            
+
             if (!$reservation_id) {
                 throw new Exception('Failed to create reservation');
             }
-            
-            $this->sendGuestNotifications($reservation_id);
-            
+
             return array(
                 'success' => true,
                 'message' => 'Generic booking processed successfully',
@@ -577,21 +572,13 @@ class GMS_Webhook_Handler {
     
     private function sendGuestNotifications($reservation_id) {
         $reservation = GMS_Database::getReservationById($reservation_id);
-        
+
         if (!$reservation) {
             return false;
         }
-        
-        // Send email notification
-        $email_handler = new GMS_Email_Handler();
-        $email_result = $email_handler->sendWelcomeEmail($reservation);
-        
-        // Send SMS notification if phone number is available
-        if (!empty($reservation['guest_phone'])) {
-            $sms_handler = new GMS_SMS_Handler();
-            $sms_result = $sms_handler->sendWelcomeSMS($reservation);
-        }
-        
+
+        gms_send_guest_notifications($reservation_id);
+
         return true;
     }
     


### PR DESCRIPTION
## Summary
- set webhook-created reservations to a pending state and stop auto-dispatching guest notifications until approval
- expose the new approval workflow statuses and templates in the admin UI while updating helper logic and cron filters to respect them
- add Reservation Approved email/SMS templates and senders that trigger automatically when a reservation status changes to approved

## Testing
- php -l guest-management-system.php
- php -l includes/class-admin.php
- php -l includes/class-database.php
- php -l includes/class-email-handler.php
- php -l includes/class-sms-handler.php
- php -l includes/class-webhook-handler.php
- php -l includes/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d9cd730a348324a6e163376b1aee38