### PR TITLE
Fix guest portal permalink helper

### DIFF
--- a/includes/class-email-handler.php
+++ b/includes/class-email-handler.php
@@ -27,7 +27,10 @@ class GMS_Email_Handler {
         $template = get_option('gms_email_template');
         $subject = 'Complete Your Check-in for ' . $reservation['property_name'];
 
-        $portal_url = home_url('/guest-portal/' . $reservation['portal_token']);
+        $portal_url = gms_build_portal_url($reservation['portal_token']);
+        if ($portal_url === false) {
+            $portal_url = '';
+        }
         
         $replacements = array(
             '{guest_name}' => $reservation['guest_name'],
@@ -79,7 +82,10 @@ class GMS_Email_Handler {
             $reservation['property_name']
         );
 
-        $portal_url = home_url('/guest-portal/' . $reservation['portal_token']);
+        $portal_url = gms_build_portal_url($reservation['portal_token']);
+        if ($portal_url === false) {
+            $portal_url = '';
+        }
 
         $replacements = array(
             '{guest_name}' => $reservation['guest_name'],
@@ -128,7 +134,10 @@ class GMS_Email_Handler {
     public function sendReminderEmail($reservation) {
         $subject = 'Reminder: Complete Your Check-in';
         
-        $portal_url = home_url('/guest-portal/' . $reservation['portal_token']);
+        $portal_url = gms_build_portal_url($reservation['portal_token']);
+        if ($portal_url === false) {
+            $portal_url = '';
+        }
         
         $message = "Hi {$reservation['guest_name']},\n\n";
         $message .= "This is a friendly reminder to complete your check-in process for {$reservation['property_name']}.\n\n";
@@ -229,7 +238,10 @@ class GMS_Email_Handler {
         
         // Add portal button if reservation provided
         if ($reservation) {
-            $portal_url = home_url('/guest-portal/' . $reservation['portal_token']);
+            $portal_url = gms_build_portal_url($reservation['portal_token']);
+            if ($portal_url === false) {
+                $portal_url = '';
+            }
             $html .= '
                     <tr>
                         <td align="center" style="padding: 0 30px 40px 30px;">
@@ -274,7 +286,11 @@ class GMS_Email_Handler {
                 $message .= "Check-out: " . date('M j, Y g:i A', strtotime($reservation['checkout_date'])) . "\n";
                 $message .= "Booking Reference: {$reservation['booking_reference']}\n";
                 $message .= "Platform: {$reservation['platform']}\n\n";
-                $message .= "Guest Portal: " . home_url('/guest-portal/' . $reservation['portal_token']);
+                $portal_url = gms_build_portal_url($reservation['portal_token']);
+                if ($portal_url === false) {
+                    $portal_url = '';
+                }
+                $message .= "Guest Portal: " . $portal_url;
                 break;
                 
             case 'check_in_complete':

--- a/includes/class-sms-handler.php
+++ b/includes/class-sms-handler.php
@@ -28,7 +28,10 @@ class GMS_SMS_Handler {
 
         $template = get_option('gms_sms_template');
         $portal_token = isset($reservation['portal_token']) ? sanitize_text_field($reservation['portal_token']) : '';
-        $portal_url = home_url('/guest-portal/' . $portal_token);
+        $portal_url = gms_build_portal_url($portal_token);
+        if ($portal_url === false) {
+            $portal_url = '';
+        }
 
         $checkin_date_raw = isset($reservation['checkin_date']) ? $reservation['checkin_date'] : '';
         $checkout_date_raw = isset($reservation['checkout_date']) ? $reservation['checkout_date'] : '';
@@ -82,7 +85,10 @@ class GMS_SMS_Handler {
         }
 
         $portal_token = isset($reservation['portal_token']) ? sanitize_text_field($reservation['portal_token']) : '';
-        $portal_url = home_url('/guest-portal/' . $portal_token);
+        $portal_url = gms_build_portal_url($portal_token);
+        if ($portal_url === false) {
+            $portal_url = '';
+        }
 
         $checkin_date_raw = isset($reservation['checkin_date']) ? $reservation['checkin_date'] : '';
         $checkout_date_raw = isset($reservation['checkout_date']) ? $reservation['checkout_date'] : '';
@@ -185,7 +191,10 @@ class GMS_SMS_Handler {
 
         $template = get_option('gms_sms_reminder_template');
         $portal_token = isset($reservation['portal_token']) ? sanitize_text_field($reservation['portal_token']) : '';
-        $portal_url = home_url('/guest-portal/' . $portal_token);
+        $portal_url = gms_build_portal_url($portal_token);
+        if ($portal_url === false) {
+            $portal_url = '';
+        }
 
         $checkin_date_raw = isset($reservation['checkin_date']) ? $reservation['checkin_date'] : '';
         $checkout_date_raw = isset($reservation['checkout_date']) ? $reservation['checkout_date'] : '';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -55,16 +55,53 @@ function gms_is_reservation_complete($reservation_id) {
 }
 
 /**
+ * Build the guest portal URL for a token.
+ *
+ * @param string $token Portal token.
+ *
+ * @return string|false
+ */
+function gms_build_portal_url($token) {
+    if (!is_scalar($token)) {
+        return false;
+    }
+
+    $token = trim((string) $token);
+
+    if ($token === '') {
+        return false;
+    }
+
+    global $wp_rewrite;
+
+    $encoded_token = rawurlencode($token);
+
+    if (is_object($wp_rewrite) && method_exists($wp_rewrite, 'using_permalinks') && $wp_rewrite->using_permalinks()) {
+        $path = 'guest-portal/' . $encoded_token;
+
+        return home_url(user_trailingslashit($path));
+    }
+
+    return add_query_arg(
+        array(
+            'guest_portal' => 1,
+            'guest_token'  => $encoded_token,
+        ),
+        home_url('/')
+    );
+}
+
+/**
  * Get portal URL for reservation
  */
 function gms_get_portal_url($reservation_id) {
     $reservation = GMS_Database::getReservationById($reservation_id);
-    
-    if (!$reservation) {
+
+    if (!$reservation || empty($reservation['portal_token'])) {
         return false;
     }
-    
-    return home_url('/guest-portal/' . $reservation['portal_token']);
+
+    return gms_build_portal_url($reservation['portal_token']);
 }
 
 /**

--- a/tests/portal-url-helper-test.php
+++ b/tests/portal-url-helper-test.php
@@ -1,0 +1,265 @@
+<?php
+// Minimal WordPress stubs required for including the plugin helpers.
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
+        // no-op for testing
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
+        // no-op for testing
+    }
+}
+
+if (!function_exists('add_shortcode')) {
+    function add_shortcode($tag, $callback) {
+        // no-op for testing
+    }
+}
+
+if (!function_exists('shortcode_atts')) {
+    function shortcode_atts($pairs, $atts) {
+        $atts = (array) $atts;
+        return array_merge($pairs, array_intersect_key($atts, $pairs));
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url) {
+        return $url;
+    }
+}
+
+if (!function_exists('home_url')) {
+    function home_url($path = '') {
+        $base = 'https://example.com';
+        $path = (string) $path;
+
+        if ($path === '' || $path === '/') {
+            return $base . '/';
+        }
+
+        if ($path[0] !== '/') {
+            $path = '/' . $path;
+        }
+
+        return $base . $path;
+    }
+}
+
+if (!function_exists('user_trailingslashit')) {
+    function user_trailingslashit($string) {
+        $string = (string) $string;
+        return rtrim($string, '/') . '/';
+    }
+}
+
+if (!function_exists('add_query_arg')) {
+    function add_query_arg($args, $url) {
+        $url_parts = parse_url($url);
+        $existing = array();
+
+        if (!empty($url_parts['query'])) {
+            parse_str($url_parts['query'], $existing);
+        }
+
+        $merged = array_merge($existing, (array) $args);
+        $query = http_build_query($merged);
+
+        $scheme   = $url_parts['scheme'] ?? 'http';
+        $host     = $url_parts['host'] ?? '';
+        $port     = isset($url_parts['port']) ? ':' . $url_parts['port'] : '';
+        $path     = $url_parts['path'] ?? '';
+        $fragment = isset($url_parts['fragment']) ? '#' . $url_parts['fragment'] : '';
+
+        $auth = '';
+        if (isset($url_parts['user'])) {
+            $auth = $url_parts['user'];
+            if (isset($url_parts['pass'])) {
+                $auth .= ':' . $url_parts['pass'];
+            }
+            $auth .= '@';
+        }
+
+        $result = $scheme . '://' . $auth . $host . $port . $path;
+        if ($query !== '') {
+            $result .= '?' . $query;
+        }
+        $result .= $fragment;
+
+        return $result;
+    }
+}
+
+// Stub localisation and sanitisation helpers used during inclusion.
+if (!function_exists('__')) {
+    function __($text, $domain = null) {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null) {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return $text;
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($text) {
+        return is_scalar($text) ? (string) $text : '';
+    }
+}
+
+if (!function_exists('maybe_serialize')) {
+    function maybe_serialize($data) {
+        if (is_array($data) || is_object($data)) {
+            return serialize($data);
+        }
+
+        if (is_serialized($data, false)) {
+            return serialize($data);
+        }
+
+        return $data;
+    }
+}
+
+if (!function_exists('is_serialized')) {
+    function is_serialized($data, $strict = true) {
+        if (!is_string($data)) {
+            return false;
+        }
+
+        $data = trim($data);
+
+        if ($data === 'N;') {
+            return true;
+        }
+
+        if (!preg_match('/^([adObis]):/', $data, $matches)) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('current_time')) {
+    function current_time($type, $gmt = 0) {
+        return '2024-01-01 00:00:00';
+    }
+}
+
+if (!function_exists('get_current_user_id')) {
+    function get_current_user_id() {
+        return 0;
+    }
+}
+
+if (!function_exists('do_action')) {
+    function do_action($hook, ...$args) {
+        // no-op
+    }
+}
+
+if (!function_exists('error_log')) {
+    function error_log($message) {
+        // no-op during tests
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = null) {
+        return $default;
+    }
+}
+
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($show = '', $filter = 'raw') {
+        return '6.0';
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        return preg_replace('/[^a-z0-9_]/', '', strtolower((string) $key));
+    }
+}
+
+if (!function_exists('wp_mail')) {
+    function wp_mail($to, $subject, $message, $headers = array()) {
+        return true;
+    }
+}
+
+if (!function_exists('wp_strip_all_tags')) {
+    function wp_strip_all_tags($string) {
+        return strip_tags($string);
+    }
+}
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook($file, $callback) {
+        // no-op for testing
+    }
+}
+
+if (!function_exists('register_deactivation_hook')) {
+    function register_deactivation_hook($file, $callback) {
+        // no-op for testing
+    }
+}
+
+if (!function_exists('wp_next_scheduled')) {
+    function wp_next_scheduled($hook) {
+        return false;
+    }
+}
+
+if (!function_exists('wp_schedule_event')) {
+    function wp_schedule_event($timestamp, $recurrence, $hook) {
+        // no-op for testing
+    }
+}
+
+if (!function_exists('wp_clear_scheduled_hook')) {
+    function wp_clear_scheduled_hook($hook) {
+        // no-op for testing
+    }
+}
+
+if (!function_exists('is_email')) {
+    function is_email($email) {
+        return (bool) filter_var($email, FILTER_VALIDATE_EMAIL);
+    }
+}
+
+require_once __DIR__ . '/../includes/functions.php';
+
+// Ensure permalinks are disabled for this test run.
+$wp_rewrite = new class {
+    public $front = '';
+    public function using_permalinks() {
+        return false;
+    }
+};
+
+$result = gms_build_portal_url('Token With Spaces');
+$expected = 'https://example.com/?guest_portal=1&guest_token=Token%2520With%2520Spaces';
+
+if ($result !== $expected) {
+    throw new RuntimeException('gms_build_portal_url produced unexpected URL: ' . var_export($result, true));
+}
+
+echo "portal-url-helper-test: OK\n";


### PR DESCRIPTION
## Summary
- ensure the guest portal permalink helper always uses the top-level guest-portal path so rewrite rules resolve correctly

## Testing
- php tests/portal-url-helper-test.php
- php tests/parse-booking-email-test.php
- php tests/parse-generic-webhook-test.php

------
https://chatgpt.com/codex/tasks/task_e_68dc6c4169d8832482edb70a480f699c