### PR TITLE
Prevent guest portal URLs from triggering WordPress 404 handling

### DIFF
--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -67,7 +67,8 @@ class GuestManagementSystem {
         // Add custom rewrite rules for the guest portal
         add_action('init', array($this, 'addRewriteRules'));
         add_filter('query_vars', array($this, 'addQueryVars'));
-        add_action('template_redirect', array($this, 'handleGuestPortal'));
+        add_action('template_redirect', array($this, 'handleGuestPortal'), 0);
+        add_filter('pre_handle_404', array($this, 'preHandlePortal404'), 0, 2);
     }
     
     private function loadIncludes() {
@@ -184,6 +185,29 @@ class GuestManagementSystem {
 
         GMS_Guest_Portal::displayPortal($token);
         exit;
+    }
+
+    public function preHandlePortal404($preempt, $wp_query) {
+        $portal_context = $this->resolvePortalRequest();
+
+        if (!$portal_context['is_portal']) {
+            return $preempt;
+        }
+
+        if ($wp_query instanceof WP_Query) {
+            $wp_query->is_404 = false;
+            $wp_query->is_home = false;
+            $wp_query->is_page = false;
+            $wp_query->set('guest_portal', 1);
+            $wp_query->set('guest_token', $portal_context['token']);
+        }
+
+        if (function_exists('set_query_var')) {
+            set_query_var('guest_portal', 1);
+            set_query_var('guest_token', $portal_context['token']);
+        }
+
+        return true;
     }
 
     public function enqueueScripts() {


### PR DESCRIPTION
## Summary
- run the guest portal template redirect handler at priority 0 so it executes before canonical redirects
- intercept portal requests on the `pre_handle_404` filter to reuse the resolver, set query vars, and stop 404 handling

## Testing
- php -l guest-management-system.php

------
https://chatgpt.com/codex/tasks/task_e_68dc8152874c8324a744c5770485da8c