### PR TITLE
Add inbound messaging ingestion and routing

### DIFF
--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -75,6 +75,7 @@ class GuestManagementSystem {
         $includes = array(
             'class-database.php',
             'class-admin.php',
+            'class-messaging-channel-interface.php',
             'class-webhook-handler.php',
             'class-guest-portal.php',
             'class-email-handler.php',
@@ -135,6 +136,7 @@ class GuestManagementSystem {
     
     public function deactivate() {
         flush_rewrite_rules();
+        wp_clear_scheduled_hook('gms_sync_provider_messages');
     }
     
     private function addGuestRole() {

--- a/includes/class-messaging-channel-interface.php
+++ b/includes/class-messaging-channel-interface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Messaging channel interface for inbound/outbound providers.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!interface_exists('GMS_Messaging_Channel_Interface')) {
+    interface GMS_Messaging_Channel_Interface {
+        public function syncProviderInbox($args = array());
+
+        public function ingestWebhookPayload(array $payload, $request = null);
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -621,6 +621,7 @@ register_deactivation_hook(__FILE__, 'gms_clear_cron');
 
 function gms_clear_cron() {
     wp_clear_scheduled_hook('gms_send_reminder_notifications');
+    wp_clear_scheduled_hook('gms_sync_provider_messages');
 }
 
 add_action('gms_reservation_status_updated', 'gms_handle_reservation_status_transition', 10, 3);


### PR DESCRIPTION
## Summary
- add a shared messaging channel interface and load it with the plugin
- expand the SMS handler with inbox polling, webhook ingestion, cron/CLI hooks, and normalized persistence
- extend database and webhook logic to match guests/reservations, deduplicate provider messages, and expose a REST inbox endpoint
- ensure new schedules are cleared on deactivation and reuse the shared auth for messaging webhooks

## Testing
- php -l guest-management-system.php
- php -l includes/class-database.php
- php -l includes/class-sms-handler.php
- php -l includes/class-webhook-handler.php
- php -l includes/functions.php
- php -l includes/class-messaging-channel-interface.php

------
https://chatgpt.com/codex/tasks/task_e_68dd3073e7e08324ba2fc069fb6670b7