### PR TITLE
Add admin-managed messaging templates and dynamic picker

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -59,6 +59,53 @@
     margin-right: 10px;
 }
 
+.gms-settings__divider {
+    border: 0;
+    border-top: 1px solid #dcdcde;
+    margin: 40px 0 30px;
+}
+
+.gms-quick-templates {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1.1fr);
+    gap: 24px;
+    margin-top: 20px;
+}
+
+.gms-quick-templates__list .tablenav.top {
+    margin-bottom: 12px;
+}
+
+.gms-quick-templates__form {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
+    padding: 20px;
+}
+
+.gms-quick-templates__form .form-table th {
+    width: 140px;
+    padding-left: 0;
+}
+
+.gms-quick-templates__form .form-table td {
+    padding-right: 0;
+}
+
+.gms-quick-templates__form .form-table textarea {
+    font-family: inherit;
+}
+
+@media (max-width: 960px) {
+    .gms-quick-templates {
+        grid-template-columns: 1fr;
+    }
+
+    .gms-quick-templates__form {
+        padding: 16px;
+    }
+}
+
 /* Status Badges */
 .status-badge {
     padding: 4px 8px;

--- a/assets/css/messaging.css
+++ b/assets/css/messaging.css
@@ -260,11 +260,32 @@
 .gms-messaging__composer-row {
     display: flex;
     align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.gms-messaging__template-row {
+    align-items: stretch;
+}
+
+.gms-messaging__template-search {
+    flex: 1 1 200px;
+    min-width: 160px;
+    max-width: 320px;
 }
 
 .gms-messaging__template {
-    width: 100%;
-    max-width: 280px;
+    flex: 1 1 200px;
+    max-width: none;
+}
+
+.gms-messaging__template-row.is-loading {
+    opacity: 0.6;
+}
+
+.gms-messaging__template-row.is-loading .gms-messaging__template,
+.gms-messaging__template-row.is-loading .gms-messaging__template-search {
+    cursor: progress;
 }
 
 .gms-messaging__input {

--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -245,31 +245,6 @@ class GuestManagementSystem {
             wp_enqueue_style('gms-messaging', GMS_PLUGIN_URL . 'assets/css/messaging.css', [], GMS_VERSION);
             wp_enqueue_script('gms-messaging', GMS_PLUGIN_URL . 'assets/js/messaging.js', [], GMS_VERSION, true);
 
-            $template_map = array(
-                'gms_sms_template' => __('Primary SMS Template', 'guest-management-system'),
-                'gms_sms_reminder_template' => __('Reminder SMS Template', 'guest-management-system'),
-                'gms_approved_sms_template' => __('Approval SMS Template', 'guest-management-system'),
-            );
-
-            $templates = array();
-            foreach ($template_map as $option_key => $label) {
-                $raw_template = get_option($option_key, '');
-                if (empty($raw_template)) {
-                    continue;
-                }
-
-                $sanitized = trim(preg_replace('/\r\n|\r/', "\n", wp_specialchars_decode(wp_strip_all_tags($raw_template))));
-                if ($sanitized === '') {
-                    continue;
-                }
-
-                $templates[] = array(
-                    'id' => sanitize_key($option_key),
-                    'label' => $label,
-                    'content' => $sanitized,
-                );
-            }
-
             wp_localize_script(
                 'gms-messaging',
                 'gmsMessaging',
@@ -280,7 +255,6 @@ class GuestManagementSystem {
                     'dateFormat' => get_option('date_format', 'Y-m-d'),
                     'timeFormat' => get_option('time_format', 'H:i'),
                     'locale' => get_locale(),
-                    'templates' => $templates,
                     'strings' => array(
                         'searchPlaceholder' => __('Search guests, properties, or numbers…', 'guest-management-system'),
                         'searchAction' => __('Search', 'guest-management-system'),
@@ -294,6 +268,12 @@ class GuestManagementSystem {
                         'previousPage' => __('Previous conversations', 'guest-management-system'),
                         'nextPage' => __('Next conversations', 'guest-management-system'),
                         'templatePlaceholder' => __('Insert a template…', 'guest-management-system'),
+                        'templateSearchPlaceholder' => __('Search templates…', 'guest-management-system'),
+                        'templateLoading' => __('Loading templates…', 'guest-management-system'),
+                        'templateEmpty' => __('No templates available for this channel yet.', 'guest-management-system'),
+                        'templateEmptySearch' => __('No templates match your search.', 'guest-management-system'),
+                        'templateLoadError' => __('Unable to load templates. Please try again.', 'guest-management-system'),
+                        'templateUnavailable' => __('Select a conversation to browse templates.', 'guest-management-system'),
                         'sending' => __('Sending…', 'guest-management-system'),
                         'sendFailed' => __('Message failed to send. Please try again.', 'guest-management-system'),
                         'sendSuccess' => __('Message sent successfully.', 'guest-management-system'),

--- a/includes/class-ajax-handler.php
+++ b/includes/class-ajax-handler.php
@@ -25,6 +25,7 @@ class GMS_AJAX_Handler {
         add_action('wp_ajax_gms_fetch_thread_messages', array($this, 'fetch_thread_messages'));
         add_action('wp_ajax_gms_send_message_reply', array($this, 'send_message_reply'));
         add_action('wp_ajax_gms_mark_thread_read', array($this, 'mark_thread_read'));
+        add_action('wp_ajax_gms_list_message_templates', array($this, 'list_message_templates'));
     }
 
     /**
@@ -219,5 +220,23 @@ class GMS_AJAX_Handler {
             'updated' => $updated,
             'thread' => $context,
         ));
+    }
+
+    public function list_message_templates() {
+        $this->verify_messaging_permissions();
+
+        $channel = isset($_REQUEST['channel']) ? sanitize_key(wp_unslash($_REQUEST['channel'])) : '';
+        $search = isset($_REQUEST['search']) ? sanitize_text_field(wp_unslash($_REQUEST['search'])) : '';
+        $page = isset($_REQUEST['page']) ? max(1, intval($_REQUEST['page'])) : 1;
+        $per_page = isset($_REQUEST['per_page']) ? max(1, min(100, intval($_REQUEST['per_page']))) : 25;
+
+        $templates = GMS_Database::getMessageTemplates(array(
+            'channel' => $channel,
+            'search' => $search,
+            'page' => $page,
+            'per_page' => $per_page,
+        ));
+
+        wp_send_json_success($templates);
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated database table and CRUD helpers for reusable messaging templates
- expose template management in the admin Templates tab and via the messaging AJAX API
- refresh the inbox UI to load, search, and insert channel-aware quick replies

## Testing
- php -l includes/class-database.php
- php -l includes/class-admin.php
- php -l includes/class-ajax-handler.php
- php -l guest-management-system.php

------
https://chatgpt.com/codex/tasks/task_e_68dd386e7958832485b7554efc2b7578