### PR TITLE
Handle noop SMS sync results

### DIFF
--- a/includes/class-webhook-handler.php
+++ b/includes/class-webhook-handler.php
@@ -223,7 +223,15 @@ class GMS_Webhook_Handler {
 
         $result = $handler->ingestWebhookPayload($payload, $request);
 
-        $status = !empty($result['success']) ? 200 : 400;
+        $status = 200;
+
+        if (!empty($result['errors'])) {
+            $status = 400;
+        }
+
+        if (!empty($result['status']) && in_array($result['status'], array('error', 'partial'), true)) {
+            $status = 400;
+        }
 
         return new WP_REST_Response($result, $status);
     }


### PR DESCRIPTION
## Summary
- add explicit status metadata to SMS sync and webhook ingestion results, including a noop success case
- align CLI logging and webhook HTTP responses with the new status information

## Testing
- php -l includes/class-sms-handler.php
- php -l includes/class-webhook-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68dd4137736883249161d90678d3c84c