### PR TITLE
Initialize AJAX handler during plugin bootstrap

### DIFF
--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -54,6 +54,7 @@ class GuestManagementSystem {
         new GMS_SMS_Handler();
         new GMS_Stripe_Integration();
         new GMS_Agreement_Handler(); // Initialize the new agreement handler
+        new GMS_AJAX_Handler();
 
         GMS_Database::maybeScheduleGuestBackfill();
 
@@ -81,6 +82,7 @@ class GuestManagementSystem {
             'class-email-handler.php',
             'class-sms-handler.php',
             'class-stripe-integration.php',
+            'class-ajax-handler.php',
             'class-agreement-handler.php', // Load the new agreement handler class
             'functions.php'
         );


### PR DESCRIPTION
## Summary
- load the AJAX handler class with the rest of the plugin components
- instantiate the AJAX handler during init so its WordPress hooks register for admin requests

## Testing
- php -l guest-management-system.php

------
https://chatgpt.com/codex/tasks/task_e_68dd4835899483248fff34579da32a9c