### PR TITLE
Handle VoIP.ms webhook envelopes and phone arrays

### DIFF
--- a/tests/voipms-sms-handler-test.php
+++ b/tests/voipms-sms-handler-test.php
@@ -1,0 +1,231 @@
+<?php
+
+date_default_timezone_set('UTC');
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value) {
+        if (is_array($value)) {
+            return '';
+        }
+
+        $value = (string) $value;
+        $value = trim($value);
+        $value = preg_replace('/[\r\n\t\0\x0B]/', '', $value);
+
+        return $value;
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        $key = strtolower((string) $key);
+        $key = preg_replace('/[^a-z0-9_\-]/', '', $key);
+
+        return $key;
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = array()) {
+        return array_merge($defaults, $args);
+    }
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) {
+        return json_encode($data);
+    }
+}
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($value) {
+        return $value;
+    }
+}
+
+if (!function_exists('current_time')) {
+    function current_time($type, $gmt = false) {
+        if ($type === 'mysql') {
+            return gmdate('Y-m-d H:i:s');
+        }
+
+        return time();
+    }
+}
+
+if (!function_exists('get_option')) {
+    $GLOBALS['__gms_test_options'] = array(
+        'gms_voipms_did' => '+15550001111',
+    );
+
+    function get_option($key, $default = false) {
+        return $GLOBALS['__gms_test_options'][$key] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($key, $value) {
+        $GLOBALS['__gms_test_options'][$key] = $value;
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value) {
+        return $value;
+    }
+}
+
+if (!class_exists('GMS_Database')) {
+    class GMS_Database {
+        public static $last_log = null;
+
+        public static function normalizePhoneNumber($number) {
+            $number = preg_replace('/[^0-9+]/', '', (string) $number);
+
+            if ($number === '') {
+                return '';
+            }
+
+            if ($number[0] !== '+') {
+                $number = '+' . ltrim($number, '+');
+            }
+
+            return $number;
+        }
+
+        public static function communicationExists($external_id, $channel) {
+            return 0;
+        }
+
+        public static function resolveMessageContext($channel, $from, $to, $direction) {
+            return array(
+                'matched' => true,
+                'guest_number_e164' => self::normalizePhoneNumber($direction === 'inbound' ? $from : $to),
+                'service_number_e164' => self::normalizePhoneNumber($direction === 'inbound' ? $to : $from),
+                'reservation_id' => 0,
+                'guest_id' => 0,
+                'thread_key' => 'test-thread',
+            );
+        }
+
+        public static function logCommunication($data) {
+            self::$last_log = $data;
+
+            return 101;
+        }
+    }
+}
+
+if (!interface_exists('GMS_Messaging_Channel_Interface')) {
+    interface GMS_Messaging_Channel_Interface {}
+}
+
+require_once __DIR__ . '/../includes/class-sms-handler.php';
+
+if (!class_exists('Testable_GMS_SMS_Handler')) {
+    class Testable_GMS_SMS_Handler extends GMS_SMS_Handler {
+        public function __construct() {
+            // Skip WordPress hook registration during tests
+        }
+    }
+}
+
+function invoke_sms_handler_private($object, $method, array $args = array()) {
+    $reflection = new ReflectionMethod(get_class($object), $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invokeArgs($object, $args);
+}
+
+$payload = array(
+    'body' => array(
+        'payload' => array(
+            'messages' => array(
+                array(
+                    'id' => 'sms-123',
+                    'direction' => 'inbound',
+                    'from' => array(
+                        'phone_number' => '+12223334444',
+                        'name' => 'Alice Example',
+                    ),
+                    'to' => array(
+                        array(
+                            'phone_number' => '+15550001111',
+                            'name' => 'Office Line',
+                        ),
+                        array(
+                            'phone_number' => '+15550002222',
+                            'name' => 'Fallback',
+                        ),
+                    ),
+                    'text' => 'Sample webhook message',
+                    'received_at' => '2024-05-30T17:12:34-04:00',
+                ),
+            ),
+        ),
+    ),
+);
+
+$handler = new Testable_GMS_SMS_Handler();
+
+$messages = invoke_sms_handler_private($handler, 'extractMessagesFromPayload', array($payload));
+
+if (!is_array($messages) || count($messages) !== 1) {
+    throw new RuntimeException('Expected a single message from payload: ' . json_encode($messages));
+}
+
+$extracted = $messages[0];
+
+if (($extracted['text'] ?? null) !== 'Sample webhook message') {
+    throw new RuntimeException('Message text was not preserved: ' . json_encode($extracted));
+}
+
+$normalized = invoke_sms_handler_private($handler, 'normalizeVoipmsMessage', array($extracted));
+
+if (!is_string($normalized['from']) || $normalized['from'] !== '+12223334444') {
+    throw new RuntimeException('Normalized "from" was not flattened: ' . json_encode($normalized['from']));
+}
+
+if (!is_string($normalized['to']) || $normalized['to'] !== '+15550001111') {
+    throw new RuntimeException('Normalized "to" was not flattened: ' . json_encode($normalized['to']));
+}
+
+if ($normalized['from_e164'] !== '+12223334444') {
+    throw new RuntimeException('from_e164 mismatch: ' . json_encode($normalized));
+}
+
+if ($normalized['to_e164'] !== '+15550001111') {
+    throw new RuntimeException('to_e164 mismatch: ' . json_encode($normalized));
+}
+
+$expected_timestamp = gmdate('Y-m-d H:i:s', strtotime('2024-05-30T17:12:34-04:00'));
+
+if ($normalized['timestamp'] !== $expected_timestamp) {
+    throw new RuntimeException(sprintf('Timestamp mismatch. Expected %s, got %s', $expected_timestamp, $normalized['timestamp']));
+}
+
+GMS_Database::$last_log = null;
+
+$persist = invoke_sms_handler_private($handler, 'persistNormalizedMessage', array($normalized));
+
+if (empty($persist['stored'])) {
+    throw new RuntimeException('Message was not marked as stored.');
+}
+
+if (!is_array(GMS_Database::$last_log)) {
+    throw new RuntimeException('Log data was not captured.');
+}
+
+if (!is_string(GMS_Database::$last_log['from_number']) || GMS_Database::$last_log['from_number'] !== '+12223334444') {
+    throw new RuntimeException('from_number not logged as string: ' . json_encode(GMS_Database::$last_log));
+}
+
+if (!is_string(GMS_Database::$last_log['to_number']) || GMS_Database::$last_log['to_number'] !== '+15550001111') {
+    throw new RuntimeException('to_number not logged as string: ' . json_encode(GMS_Database::$last_log));
+}
+
+if (GMS_Database::$last_log['sent_at'] !== $expected_timestamp) {
+    throw new RuntimeException('sent_at did not match expected timestamp.');
+}
+
+echo "voipms-sms-handler-test: OK\n";


### PR DESCRIPTION
## Summary
- prefer request body wrappers when detecting webhook message envelopes and avoid treating message field arrays as envelopes
- flatten array-based VoIP.ms phone fields, fall back to received_at timestamps, and persist normalized strings
- add a regression test that feeds a sample VoIP.ms webhook payload through extraction, normalization, and persistence

## Testing
- php tests/voipms-sms-handler-test.php
- php tests/parse-generic-webhook-test.php

------
https://chatgpt.com/codex/tasks/task_e_68dd53dfb71c832498da5efad9f2dd55