### PR TITLE
Fix reservation bulk delete handling

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -664,11 +664,18 @@
 
         // Bulk actions for reservations
         $('#doaction, #doaction2').on('click', function(e) {
-            e.preventDefault();
-            
             var action = $(this).prev('select').val();
+
+            // Allow the standard form submission to process deletions so
+            // nonce validation and the server-side redirect/notices occur.
+            if (action === 'delete') {
+                return;
+            }
+
+            e.preventDefault();
+
             var selectedIds = [];
-            
+
             $('input[type="checkbox"]:checked').each(function() {
                 var id = $(this).val();
                 if (id && id !== 'on') {


### PR DESCRIPTION
## Summary
- add sorting, status/date filters, search, and bulk delete handling to the reservations list table
- provide guest list sorting, filtering, editing UI, and delete handling backed by new database helpers
- link dashboard stats to filtered reservation views and surface edit/delete shortcuts for recent reservations
- ensure reservation bulk delete falls back to the native form submission so server-side deletion and notices run reliably

## Testing
- php -l includes/class-database.php
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68dd8a43486483248bc643e7a171f93b