### PR TITLE
Add guest contact intake step to portal

### DIFF
--- a/includes/class-guest-portal.php
+++ b/includes/class-guest-portal.php
@@ -11,6 +11,8 @@ class GMS_Guest_Portal {
     public function __construct() {
         add_action('wp_ajax_gms_submit_agreement', array($this, 'submitAgreement'));
         add_action('wp_ajax_nopriv_gms_submit_agreement', array($this, 'submitAgreement'));
+        add_action('wp_ajax_gms_update_contact_info', array($this, 'updateContactInfo'));
+        add_action('wp_ajax_nopriv_gms_update_contact_info', array($this, 'updateContactInfo'));
         add_action('wp_ajax_gms_create_verification_session', array($this, 'createVerificationSession'));
         add_action('wp_ajax_nopriv_gms_create_verification_session', array($this, 'createVerificationSession'));
         add_action('wp_ajax_gms_check_verification_status', array($this, 'checkVerificationStatus'));
@@ -51,7 +53,60 @@ class GMS_Guest_Portal {
             $door_code = GMS_Database::sanitizeDoorCode($reservation['door_code']);
         }
         $secondary_color = get_option('gms_portal_secondary_color', '#005a87');
-        
+
+        $guest_profile = null;
+        if (!empty($reservation['guest_id'])) {
+            $guest_profile = GMS_Database::get_guest_by_id($reservation['guest_id']);
+        }
+
+        $contact_first_name = trim((string) ($guest_profile['first_name'] ?? ''));
+        $contact_last_name = trim((string) ($guest_profile['last_name'] ?? ''));
+        $contact_email = trim((string) ($guest_profile['email'] ?? $reservation['guest_email'] ?? ''));
+        $contact_phone = trim((string) ($guest_profile['phone'] ?? $reservation['guest_phone'] ?? ''));
+
+        if ($contact_first_name === '' || $contact_last_name === '') {
+            list($split_first, $split_last) = self::splitGuestName($reservation['guest_name'] ?? '');
+            if ($contact_first_name === '') {
+                $contact_first_name = $split_first;
+            }
+            if ($contact_last_name === '') {
+                $contact_last_name = $split_last;
+            }
+        }
+
+        $contact_first_name = sanitize_text_field($contact_first_name);
+        $contact_last_name = sanitize_text_field($contact_last_name);
+        $contact_email = sanitize_email($contact_email);
+        $contact_phone = function_exists('gms_sanitize_phone')
+            ? gms_sanitize_phone($contact_phone)
+            : preg_replace('/[^0-9+]/', '', $contact_phone);
+
+        $contact_full_name = trim($contact_first_name . ' ' . $contact_last_name);
+
+        if ($contact_full_name !== '') {
+            $reservation['guest_name'] = $contact_full_name;
+        }
+
+        if ($contact_email !== '') {
+            $reservation['guest_email'] = $contact_email;
+        }
+
+        if ($contact_phone !== '') {
+            $reservation['guest_phone'] = $contact_phone;
+        }
+
+        $contact_info_complete = $contact_first_name !== '' && $contact_last_name !== '' && $contact_email !== '' && $contact_phone !== '';
+
+        $contact_phone_display = $contact_phone;
+        if ($contact_phone_display !== '' && function_exists('gms_format_phone')) {
+            $formatted_phone = gms_format_phone($contact_phone_display);
+            if (!empty($formatted_phone)) {
+                $contact_phone_display = $formatted_phone;
+            }
+        }
+
+        $display_guest_name = $reservation['guest_name'];
+
         $agreement_template = get_option('gms_agreement_template', '');
 
         if (!is_string($agreement_template) || trim($agreement_template) === '') {
@@ -59,18 +114,7 @@ class GMS_Guest_Portal {
             return;
         }
 
-        // Replace template variables
-        $agreement_display = str_replace(
-            ['{guest_name}', '{guest_email}', '{guest_phone}', '{property_name}', '{booking_reference}',
-             '{checkin_date}', '{checkout_date}', '{checkin_time}', '{checkout_time}', '{company_name}'],
-            [$reservation['guest_name'], $reservation['guest_email'], $reservation['guest_phone'],
-             $reservation['property_name'], $reservation['booking_reference'],
-             date('F j, Y', strtotime($reservation['checkin_date'])),
-             date('F j, Y', strtotime($reservation['checkout_date'])),
-             $reservation['checkin_time'] ?? '3:00 PM', $reservation['checkout_time'] ?? '11:00 AM',
-             $company_name],
-            $agreement_template
-        );
+        $agreement_display = self::renderAgreementTemplate($reservation, $company_name, $agreement_template);
 
         ?>
         <!DOCTYPE html>
@@ -152,7 +196,55 @@ class GMS_Guest_Portal {
                 .checklist {
                     margin-bottom: 2rem;
                 }
-                
+
+                .form-grid {
+                    display: grid;
+                    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+                    gap: 1rem;
+                    margin-bottom: 1rem;
+                }
+
+                .form-group {
+                    display: flex;
+                    flex-direction: column;
+                    text-align: left;
+                }
+
+                .form-group label {
+                    font-weight: 600;
+                    margin-bottom: 0.4rem;
+                }
+
+                .form-group input {
+                    padding: 0.75rem;
+                    border: 1px solid #ccc;
+                    border-radius: 4px;
+                    font-size: 1rem;
+                }
+
+                .text-muted {
+                    color: #666;
+                    font-size: 0.95rem;
+                }
+
+                .contact-summary {
+                    background: #f8f9fa;
+                    border-radius: 6px;
+                    padding: 1rem 1.25rem;
+                    margin-bottom: 1rem;
+                }
+
+                .contact-summary ul {
+                    list-style: none;
+                    margin: 0;
+                    padding: 0;
+                }
+
+                .contact-summary li {
+                    margin-bottom: 0.5rem;
+                    color: #555;
+                }
+
                 .checklist-item {
                     display: flex;
                     align-items: center;
@@ -369,12 +461,16 @@ class GMS_Guest_Portal {
                     .portal-content {
                         padding: 1rem;
                     }
-                    
+
                     .booking-details {
                         grid-template-columns: 1fr;
                         gap: 0.5rem;
                     }
-                    
+
+                    .form-grid {
+                        grid-template-columns: 1fr;
+                    }
+
                     .detail-item {
                         text-align: left;
                         padding: 0.5rem;
@@ -413,7 +509,7 @@ class GMS_Guest_Portal {
                 
                 <div class="portal-content">
                     <div class="welcome-section">
-                        <h2>Hello, <?php echo esc_html($reservation['guest_name']); ?>!</h2>
+                        <h2>Hello, <span id="guest-name-display"><?php echo esc_html($display_guest_name); ?></span>!</h2>
                         <p>We're excited to host you. Please complete the following steps to finalize your check-in.</p>
                     </div>
                     
@@ -449,19 +545,29 @@ class GMS_Guest_Portal {
                     </div>
                     
                     <div class="checklist">
+                        <div class="checklist-item <?php echo $contact_info_complete ? 'completed' : ''; ?>" id="contact-checklist">
+                            <div class="checklist-icon">
+                                <?php echo $contact_info_complete ? '✓' : '1'; ?>
+                            </div>
+                            <div class="checklist-content">
+                                <div class="checklist-title">Confirm Guest Details</div>
+                                <div class="checklist-description">Share your contact information so we can finalize your stay</div>
+                            </div>
+                        </div>
+
                         <div class="checklist-item <?php echo ($agreement && $agreement['status'] === 'signed') ? 'completed' : ''; ?>" id="agreement-checklist">
                             <div class="checklist-icon">
-                                <?php echo ($agreement && $agreement['status'] === 'signed') ? '✓' : '1'; ?>
+                                <?php echo ($agreement && $agreement['status'] === 'signed') ? '✓' : '2'; ?>
                             </div>
                             <div class="checklist-content">
                                 <div class="checklist-title">Sign Guest Agreement</div>
                                 <div class="checklist-description">Review and sign our property agreement</div>
                             </div>
                         </div>
-                        
+
                         <div class="checklist-item <?php echo ($verification && $verification['verification_status'] === 'verified') ? 'completed' : ''; ?>" id="verification-checklist">
                             <div class="checklist-icon">
-                                <?php echo ($verification && $verification['verification_status'] === 'verified') ? '✓' : '2'; ?>
+                                <?php echo ($verification && $verification['verification_status'] === 'verified') ? '✓' : '3'; ?>
                             </div>
                             <div class="checklist-content">
                                 <div class="checklist-title">Identity Verification</div>
@@ -469,12 +575,57 @@ class GMS_Guest_Portal {
                             </div>
                         </div>
                     </div>
-                    
+
+                    <!-- Contact Information Section -->
+                    <div class="action-section" id="contact-section">
+                        <h3 class="section-title">👤 Guest Details</h3>
+
+                        <div class="contact-summary <?php echo $contact_info_complete ? '' : 'hidden'; ?>" id="contact-info-summary">
+                            <p class="text-muted" style="margin-bottom: 0.75rem;">We'll use these details to send arrival information and important updates about your stay.</p>
+                            <ul>
+                                <li><strong>Name:</strong> <span id="contact-summary-name"><?php echo esc_html($reservation['guest_name']); ?></span></li>
+                                <li><strong>Email:</strong> <span id="contact-summary-email"><?php echo esc_html($reservation['guest_email']); ?></span></li>
+                                <li><strong>Mobile:</strong> <span id="contact-summary-phone"><?php echo esc_html($contact_phone_display); ?></span></li>
+                            </ul>
+                        </div>
+
+                        <p class="text-muted" id="contact-section-helper" style="margin-bottom: 1rem;">
+                            <?php if ($contact_info_complete): ?>
+                                <?php esc_html_e('Need to make a change? Update your contact details below.', 'gms'); ?>
+                            <?php else: ?>
+                                <?php esc_html_e('We need your legal name and contact information before we can confirm the reservation. The remaining steps will unlock once this is saved.', 'gms'); ?>
+                            <?php endif; ?>
+                        </p>
+
+                        <form id="contact-info-form" novalidate>
+                            <div class="form-grid">
+                                <div class="form-group">
+                                    <label for="guest-first-name"><?php esc_html_e('First Name', 'gms'); ?></label>
+                                    <input type="text" id="guest-first-name" name="first_name" value="<?php echo esc_attr($contact_first_name); ?>" required autocomplete="given-name">
+                                </div>
+                                <div class="form-group">
+                                    <label for="guest-last-name"><?php esc_html_e('Last Name', 'gms'); ?></label>
+                                    <input type="text" id="guest-last-name" name="last_name" value="<?php echo esc_attr($contact_last_name); ?>" required autocomplete="family-name">
+                                </div>
+                                <div class="form-group">
+                                    <label for="guest-email"><?php esc_html_e('Email', 'gms'); ?></label>
+                                    <input type="email" id="guest-email" name="email" value="<?php echo esc_attr($reservation['guest_email']); ?>" required autocomplete="email">
+                                </div>
+                                <div class="form-group">
+                                    <label for="guest-phone"><?php esc_html_e('Mobile Phone', 'gms'); ?></label>
+                                    <input type="tel" id="guest-phone" name="phone" value="<?php echo esc_attr($reservation['guest_phone']); ?>" required autocomplete="tel">
+                                </div>
+                            </div>
+                            <button id="save-contact-info" class="btn btn-primary" type="submit"><?php echo esc_html($contact_info_complete ? __('Update Details', 'gms') : __('Save & Continue', 'gms')); ?></button>
+                            <div id="contact-info-message"></div>
+                        </form>
+                    </div>
+
                     <!-- Agreement Section -->
-                    <div class="action-section" id="agreement-section" <?php echo ($agreement && $agreement['status'] === 'signed') ? 'style="display: none;"' : ''; ?>>
+                    <div class="action-section requires-contact-info <?php echo $contact_info_complete ? '' : 'hidden'; ?>" id="agreement-section" <?php echo ($agreement && $agreement['status'] === 'signed') ? 'style="display: none;"' : ''; ?>>
                         <h3 class="section-title">📋 Guest Agreement</h3>
-                        
-                        <div class="agreement-text">
+
+                        <div class="agreement-text" id="agreement-text">
                             <?php echo wp_kses_post($agreement_display); ?>
                         </div>
                         
@@ -497,7 +648,7 @@ class GMS_Guest_Portal {
                     
                     <!-- PDF Download Section (shown after signing) -->
                     <?php if ($agreement && $agreement['status'] === 'signed' && !empty($agreement['pdf_url'])): ?>
-                    <div class="pdf-download-section">
+                    <div class="pdf-download-section requires-contact-info <?php echo $contact_info_complete ? '' : 'hidden'; ?>">
                         <h3 class="section-title">✅ Agreement Signed Successfully</h3>
                         <div class="pdf-download-box">
                             <p style="margin-bottom: 1rem;"><strong>Your agreement has been signed and saved!</strong></p>
@@ -514,7 +665,7 @@ class GMS_Guest_Portal {
                     <?php endif; ?>
                     
                     <!-- Identity Verification Section -->
-                    <div class="action-section" id="verification-section" <?php echo (!$agreement || $agreement['status'] !== 'signed') ? 'style="display: none;"' : ''; ?>>
+                    <div class="action-section requires-contact-info <?php echo $contact_info_complete ? '' : 'hidden'; ?>" id="verification-section" <?php echo (!$agreement || $agreement['status'] !== 'signed') ? 'style="display: none;"' : ''; ?>>
                         <h3 class="section-title">🆔 Identity Verification</h3>
                         
                         <p>Please verify your identity by uploading a photo of your government-issued ID and capturing a live selfie that matches your ID photo. This helps us ensure the security of our properties.</p>
@@ -548,8 +699,41 @@ class GMS_Guest_Portal {
                 // Initialize variables
                 let signaturePad = null;
                 let stripe = null;
+                let contactInfoComplete = <?php echo $contact_info_complete ? 'true' : 'false'; ?>;
                 const reservationId = <?php echo intval($reservation['id']); ?>;
                 const portalToken = '<?php echo esc_js($reservation['portal_token']); ?>';
+                const ajaxUrl = '<?php echo esc_url(admin_url('admin-ajax.php')); ?>';
+                const guestNonce = '<?php echo wp_create_nonce('gms_guest_nonce'); ?>';
+                const contactHelperMessages = {
+                    complete: '<?php echo esc_js(__('Need to make a change? Update your contact details below.', 'gms')); ?>',
+                    incomplete: '<?php echo esc_js(__('We need your legal name and contact information before we can confirm the reservation. The remaining steps will unlock once this is saved.', 'gms')); ?>'
+                };
+                const contactSavingMessage = '<?php echo esc_js(__('Saving your details…', 'gms')); ?>';
+                const contactButtonLabels = {
+                    save: '<?php echo esc_js(__('Save & Continue', 'gms')); ?>',
+                    update: '<?php echo esc_js(__('Update Details', 'gms')); ?>',
+                    saving: contactSavingMessage
+                };
+                const contactSuccessMessage = '<?php echo esc_js(__('Contact information saved. You can move on to the next step.', 'gms')); ?>';
+                const contactFailureMessage = '<?php echo esc_js(__('Unable to save contact information. Please try again.', 'gms')); ?>';
+                const contactNetworkErrorMessage = '<?php echo esc_js(__('We could not save your details due to a network error. Please try again.', 'gms')); ?>';
+                const contactMissingConfigMessage = '<?php echo esc_js(__('We could not save your details because the portal is missing required configuration.', 'gms')); ?>';
+
+                window.gmsReservationId = reservationId;
+                window.gmsAjaxUrl = ajaxUrl;
+                window.gmsNonce = guestNonce;
+                window.gmsContactInfoComplete = contactInfoComplete;
+                window.gmsContactStrings = {
+                    helperComplete: contactHelperMessages.complete,
+                    helperIncomplete: contactHelperMessages.incomplete,
+                    saving: contactButtonLabels.saving,
+                    success: contactSuccessMessage,
+                    failure: contactFailureMessage,
+                    networkError: contactNetworkErrorMessage,
+                    saveLabel: contactButtonLabels.save,
+                    updateLabel: contactButtonLabels.update,
+                    missingConfig: contactMissingConfigMessage
+                };
                 
                 // Initialize Stripe
                 <?php if (get_option('gms_stripe_pk')): ?>
@@ -558,6 +742,8 @@ class GMS_Guest_Portal {
                 
                 document.addEventListener('DOMContentLoaded', function() {
                     initializeSignaturePad();
+                    setupContactForm();
+                    toggleContactDependentSections();
                     updateProgress();
                     setupEventListeners();
                 });
@@ -644,7 +830,250 @@ class GMS_Guest_Portal {
                         }
                     };
                 }
-                
+
+                function setupContactForm() {
+                    const contactForm = document.getElementById('contact-info-form');
+                    if (!contactForm) {
+                        return;
+                    }
+
+                    const submitBtn = document.getElementById('save-contact-info');
+                    const messageDiv = document.getElementById('contact-info-message');
+                    const helper = document.getElementById('contact-section-helper');
+
+                    if (helper) {
+                        helper.textContent = contactInfoComplete ? contactHelperMessages.complete : contactHelperMessages.incomplete;
+                    }
+
+                    const inputs = contactForm.querySelectorAll('input');
+
+                    function updateSubmitState() {
+                        if (!submitBtn) {
+                            return;
+                        }
+                        submitBtn.disabled = !contactForm.checkValidity();
+                    }
+
+                    inputs.forEach((input) => {
+                        input.addEventListener('input', updateSubmitState);
+                        input.addEventListener('blur', function() {
+                            this.value = this.value.trim();
+                            updateSubmitState();
+                        });
+                    });
+
+                    updateSubmitState();
+
+                    contactForm.addEventListener('submit', function(event) {
+                        event.preventDefault();
+
+                        if (!contactForm.checkValidity()) {
+                            contactForm.reportValidity();
+                            return;
+                        }
+
+                        submitContactInfo({
+                            contactForm: contactForm,
+                            submitBtn: submitBtn,
+                            messageDiv: messageDiv,
+                            helper: helper,
+                            updateSubmitState: updateSubmitState
+                        });
+                    });
+                }
+
+                function toggleContactDependentSections() {
+                    const gatedSections = document.querySelectorAll('.requires-contact-info');
+                    gatedSections.forEach((section) => {
+                        if (contactInfoComplete) {
+                            section.classList.remove('hidden');
+                        } else {
+                            section.classList.add('hidden');
+                        }
+                    });
+                }
+
+                function updateContactSummary(payload) {
+                    const summary = document.getElementById('contact-info-summary');
+                    if (summary) {
+                        if (payload.guest_name) {
+                            const nameEl = document.getElementById('contact-summary-name');
+                            if (nameEl) {
+                                nameEl.textContent = payload.guest_name;
+                            }
+                        }
+
+                        if (payload.guest_email) {
+                            const emailEl = document.getElementById('contact-summary-email');
+                            if (emailEl) {
+                                emailEl.textContent = payload.guest_email;
+                            }
+                        }
+
+                        if (payload.display_phone || payload.guest_phone) {
+                            const phoneEl = document.getElementById('contact-summary-phone');
+                            if (phoneEl) {
+                                phoneEl.textContent = payload.display_phone || payload.guest_phone;
+                            }
+                        }
+
+                        summary.classList.remove('hidden');
+                    }
+
+                    const helper = document.getElementById('contact-section-helper');
+                    if (helper) {
+                        helper.textContent = contactHelperMessages.complete;
+                    }
+                }
+
+                function submitContactInfo(context) {
+                    const { contactForm, submitBtn, messageDiv, helper, updateSubmitState } = context;
+                    const wasComplete = contactInfoComplete;
+
+                    const firstNameInput = document.getElementById('guest-first-name');
+                    const lastNameInput = document.getElementById('guest-last-name');
+                    const emailInput = document.getElementById('guest-email');
+                    const phoneInput = document.getElementById('guest-phone');
+
+                    const firstName = firstNameInput ? firstNameInput.value.trim() : '';
+                    const lastName = lastNameInput ? lastNameInput.value.trim() : '';
+                    const email = emailInput ? emailInput.value.trim() : '';
+                    const phone = phoneInput ? phoneInput.value.trim() : '';
+
+                    if (firstNameInput) {
+                        firstNameInput.value = firstName;
+                    }
+                    if (lastNameInput) {
+                        lastNameInput.value = lastName;
+                    }
+                    if (emailInput) {
+                        emailInput.value = email;
+                    }
+                    if (phoneInput) {
+                        phoneInput.value = phone;
+                    }
+
+                    const canSubmit = reservationId > 0 && ajaxUrl !== '' && guestNonce !== '';
+                    const originalLabel = contactInfoComplete ? contactButtonLabels.update : contactButtonLabels.save;
+
+                    if (submitBtn) {
+                        submitBtn.disabled = true;
+                        submitBtn.textContent = contactButtonLabels.saving;
+                    }
+
+                    if (messageDiv) {
+                        messageDiv.innerHTML = '<div class="loading"><div class="spinner"></div><p>' + contactSavingMessage + '</p></div>';
+                    }
+
+                    if (!canSubmit) {
+                        if (messageDiv) {
+                            messageDiv.innerHTML = '<div class="error-message">❌ ' + contactMissingConfigMessage + '</div>';
+                        }
+
+                        if (submitBtn) {
+                            submitBtn.disabled = false;
+                            submitBtn.textContent = originalLabel;
+                        }
+
+                        return;
+                    }
+
+                    const formData = new FormData();
+                    formData.append('action', 'gms_update_contact_info');
+                    formData.append('reservation_id', reservationId);
+                    formData.append('nonce', guestNonce);
+                    formData.append('first_name', firstName);
+                    formData.append('last_name', lastName);
+                    formData.append('email', email);
+                    formData.append('phone', phone);
+
+                    fetch(ajaxUrl, {
+                        method: 'POST',
+                        body: formData
+                    })
+                        .then((response) => response.json())
+                        .then((data) => {
+                            if (data.success) {
+                                const payload = data.data || {};
+                                contactInfoComplete = true;
+                                window.gmsContactInfoComplete = true;
+                                updateContactSummary(payload);
+                                toggleContactDependentSections();
+
+                                const contactChecklist = document.getElementById('contact-checklist');
+                                if (contactChecklist) {
+                                    contactChecklist.classList.add('completed');
+                                    const icon = contactChecklist.querySelector('.checklist-icon');
+                                    if (icon) {
+                                        icon.textContent = '✓';
+                                    }
+                                }
+
+                                if (payload.first_name && firstNameInput) {
+                                    firstNameInput.value = payload.first_name;
+                                }
+                                if (payload.last_name && lastNameInput) {
+                                    lastNameInput.value = payload.last_name;
+                                }
+                                if (payload.guest_email && emailInput) {
+                                    emailInput.value = payload.guest_email;
+                                }
+                                if ((payload.guest_phone || payload.display_phone) && phoneInput) {
+                                    phoneInput.value = payload.guest_phone || payload.display_phone;
+                                }
+
+                                if (helper) {
+                                    helper.textContent = contactHelperMessages.complete;
+                                }
+
+                                if (messageDiv) {
+                                    messageDiv.innerHTML = '<div class="success-message">✅ ' + contactSuccessMessage + '</div>';
+                                }
+
+                                const guestNameDisplay = document.getElementById('guest-name-display');
+                                if (guestNameDisplay && payload.guest_name) {
+                                    guestNameDisplay.textContent = payload.guest_name;
+                                }
+
+                                if (payload.agreement_html) {
+                                    const agreementText = document.getElementById('agreement-text');
+                                    if (agreementText) {
+                                        agreementText.innerHTML = payload.agreement_html;
+                                    }
+                                }
+
+                                updateProgress();
+
+                                if (!wasComplete) {
+                                    const agreementSection = document.getElementById('agreement-section');
+                                    if (agreementSection) {
+                                        setTimeout(() => {
+                                            agreementSection.scrollIntoView({ behavior: 'smooth' });
+                                        }, 400);
+                                    }
+                                }
+                            } else {
+                                if (messageDiv) {
+                                    messageDiv.innerHTML = '<div class="error-message">❌ ' + (data.data || contactFailureMessage) + '</div>';
+                                }
+                            }
+                        })
+                        .catch(() => {
+                            if (messageDiv) {
+                                messageDiv.innerHTML = '<div class="error-message">❌ ' + contactNetworkErrorMessage + '</div>';
+                            }
+                        })
+                        .finally(() => {
+                            if (submitBtn) {
+                                submitBtn.textContent = contactInfoComplete ? contactButtonLabels.update : contactButtonLabels.save;
+                                submitBtn.disabled = false;
+                                if (typeof updateSubmitState === 'function') {
+                                    updateSubmitState();
+                                }
+                            }
+                        });
+                }
+
                 function setupEventListeners() {
                     // Agreement checkbox
                     const checkbox = document.getElementById('agreement-checkbox');
@@ -700,9 +1129,9 @@ class GMS_Guest_Portal {
                     formData.append('action', 'gms_submit_agreement');
                     formData.append('reservation_id', reservationId);
                     formData.append('signature_data', signaturePad.toDataURL());
-                    formData.append('nonce', '<?php echo wp_create_nonce('gms_guest_nonce'); ?>');
-                    
-                    fetch('<?php echo admin_url('admin-ajax.php'); ?>', {
+                    formData.append('nonce', guestNonce);
+
+                    fetch(ajaxUrl, {
                         method: 'POST',
                         body: formData
                     })
@@ -738,9 +1167,9 @@ class GMS_Guest_Portal {
                     const formData = new FormData();
                     formData.append('action', 'gms_create_verification_session');
                     formData.append('reservation_id', reservationId);
-                    formData.append('nonce', '<?php echo wp_create_nonce('gms_guest_nonce'); ?>');
-                    
-                    fetch('<?php echo admin_url('admin-ajax.php'); ?>', {
+                    formData.append('nonce', guestNonce);
+
+                    fetch(ajaxUrl, {
                         method: 'POST',
                         body: formData
                     })
@@ -772,9 +1201,9 @@ class GMS_Guest_Portal {
                     const formData = new FormData();
                     formData.append('action', 'gms_check_verification_status');
                     formData.append('reservation_id', reservationId);
-                    formData.append('nonce', '<?php echo wp_create_nonce('gms_guest_nonce'); ?>');
-                    
-                    fetch('<?php echo admin_url('admin-ajax.php'); ?>', {
+                    formData.append('nonce', guestNonce);
+
+                    fetch(ajaxUrl, {
                         method: 'POST',
                         body: formData
                     })
@@ -845,9 +1274,9 @@ class GMS_Guest_Portal {
                     formData.append('action', 'gms_update_reservation_status');
                     formData.append('reservation_id', reservationId);
                     formData.append('status', 'completed');
-                    formData.append('nonce', '<?php echo wp_create_nonce('gms_guest_nonce'); ?>');
+                    formData.append('nonce', guestNonce);
                     
-                    fetch('<?php echo admin_url('admin-ajax.php'); ?>', {
+                    fetch(ajaxUrl, {
                         method: 'POST',
                         body: formData
                     });
@@ -858,6 +1287,49 @@ class GMS_Guest_Portal {
         <?php
     }
     
+    private static function splitGuestName($name) {
+        $name = trim((string) $name);
+
+        if ($name === '') {
+            return array('', '');
+        }
+
+        $parts = preg_split('/\s+/', $name);
+
+        if (empty($parts)) {
+            return array('', '');
+        }
+
+        $first = array_shift($parts);
+        $last = trim(implode(' ', $parts));
+
+        return array($first ?? '', $last);
+    }
+
+    private static function renderAgreementTemplate($reservation, $company_name, $agreement_template) {
+        if (!is_array($reservation)) {
+            return $agreement_template;
+        }
+
+        $checkin_timestamp = !empty($reservation['checkin_date']) ? strtotime($reservation['checkin_date']) : false;
+        $checkout_timestamp = !empty($reservation['checkout_date']) ? strtotime($reservation['checkout_date']) : false;
+
+        $replacements = array(
+            '{guest_name}' => isset($reservation['guest_name']) ? $reservation['guest_name'] : '',
+            '{guest_email}' => isset($reservation['guest_email']) ? $reservation['guest_email'] : '',
+            '{guest_phone}' => isset($reservation['guest_phone']) ? $reservation['guest_phone'] : '',
+            '{property_name}' => isset($reservation['property_name']) ? $reservation['property_name'] : '',
+            '{booking_reference}' => isset($reservation['booking_reference']) ? $reservation['booking_reference'] : '',
+            '{checkin_date}' => $checkin_timestamp ? date('F j, Y', $checkin_timestamp) : '',
+            '{checkout_date}' => $checkout_timestamp ? date('F j, Y', $checkout_timestamp) : '',
+            '{checkin_time}' => isset($reservation['checkin_time']) ? $reservation['checkin_time'] : '3:00 PM',
+            '{checkout_time}' => isset($reservation['checkout_time']) ? $reservation['checkout_time'] : '11:00 AM',
+            '{company_name}' => $company_name,
+        );
+
+        return str_replace(array_keys($replacements), array_values($replacements), $agreement_template);
+    }
+
     private static function displayCompletionPage($reservation, $agreement, $verification) {
         $company_name = get_option('gms_company_name', get_option('blogname'));
         $company_logo = get_option('gms_company_logo');
@@ -1096,7 +1568,7 @@ class GMS_Guest_Portal {
         if (!wp_verify_nonce($_POST['nonce'], 'gms_guest_nonce')) {
             wp_send_json_error('Security check failed');
         }
-        
+
         $reservation_id = intval($_POST['reservation_id']);
         $signature_data = sanitize_textarea_field($_POST['signature_data']);
         
@@ -1154,7 +1626,123 @@ class GMS_Guest_Portal {
             wp_send_json_error('Failed to save agreement');
         }
     }
-    
+
+    public function updateContactInfo() {
+        $nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
+        if (!wp_verify_nonce($nonce, 'gms_guest_nonce')) {
+            wp_send_json_error(__('Security check failed.', 'gms'));
+        }
+
+        $reservation_id = isset($_POST['reservation_id']) ? intval($_POST['reservation_id']) : 0;
+        if ($reservation_id <= 0) {
+            wp_send_json_error(__('Invalid reservation.', 'gms'));
+        }
+
+        $reservation = GMS_Database::getReservationById($reservation_id);
+        if (!$reservation) {
+            wp_send_json_error(__('Invalid reservation.', 'gms'));
+        }
+
+        $first_name = sanitize_text_field(trim(wp_unslash($_POST['first_name'] ?? '')));
+        $last_name = sanitize_text_field(trim(wp_unslash($_POST['last_name'] ?? '')));
+        $email_raw = trim(wp_unslash($_POST['email'] ?? ''));
+        $email = sanitize_email($email_raw);
+        $phone_raw = trim(wp_unslash($_POST['phone'] ?? ''));
+        $phone = function_exists('gms_sanitize_phone')
+            ? gms_sanitize_phone($phone_raw)
+            : preg_replace('/[^0-9+]/', '', $phone_raw);
+
+        $errors = array();
+
+        if ($first_name === '') {
+            $errors[] = __('First name is required.', 'gms');
+        }
+
+        if ($last_name === '') {
+            $errors[] = __('Last name is required.', 'gms');
+        }
+
+        if ($email === '' || !is_email($email)) {
+            $errors[] = __('A valid email address is required.', 'gms');
+        }
+
+        $numeric_phone = preg_replace('/[^0-9]/', '', $phone);
+        if ($phone === '' || strlen($numeric_phone) < 7) {
+            $errors[] = __('Please enter a valid mobile phone number.', 'gms');
+        }
+
+        if (!empty($errors)) {
+            wp_send_json_error(implode(' ', array_unique($errors)));
+        }
+
+        $full_name = trim($first_name . ' ' . $last_name);
+
+        $guest_data = array(
+            'first_name' => $first_name,
+            'last_name' => $last_name,
+            'name' => $full_name,
+            'email' => $email,
+            'phone' => $phone,
+        );
+
+        $guest_id = 0;
+        $upserted_guest_id = GMS_Database::upsert_guest($guest_data, array('suppress_user_sync' => true));
+        if ($upserted_guest_id > 0) {
+            $guest_id = $upserted_guest_id;
+        } elseif (!empty($reservation['guest_id'])) {
+            $guest_id = intval($reservation['guest_id']);
+        }
+
+        $update_data = array(
+            'guest_name' => $full_name,
+            'guest_email' => $email,
+            'guest_phone' => $phone,
+        );
+
+        if ($guest_id > 0) {
+            $update_data['guest_id'] = $guest_id;
+        }
+
+        $updated = GMS_Database::updateReservation($reservation_id, $update_data);
+        if ($updated === false) {
+            wp_send_json_error(__('Unable to update reservation details.', 'gms'));
+        }
+
+        $updated_reservation = GMS_Database::getReservationById($reservation_id);
+        if (!$updated_reservation) {
+            $updated_reservation = array_merge($reservation, $update_data);
+            if ($guest_id > 0) {
+                $updated_reservation['guest_id'] = $guest_id;
+            }
+        }
+
+        $company_name = get_option('gms_company_name', get_option('blogname'));
+        $agreement_template = get_option('gms_agreement_template', '');
+        $agreement_html = '';
+
+        if (is_string($agreement_template) && trim($agreement_template) !== '') {
+            $agreement_html = self::renderAgreementTemplate($updated_reservation, $company_name, $agreement_template);
+        }
+
+        $display_phone = $phone;
+        if ($display_phone !== '' && function_exists('gms_format_phone')) {
+            $formatted_phone = gms_format_phone($display_phone);
+            if (!empty($formatted_phone)) {
+                $display_phone = $formatted_phone;
+            }
+        }
+
+        wp_send_json_success(array(
+            'guest_name' => $full_name,
+            'first_name' => $first_name,
+            'last_name' => $last_name,
+            'guest_email' => $email,
+            'guest_phone' => $phone,
+            'display_phone' => $display_phone,
+            'agreement_html' => $agreement_html,
+        ));
+    }
+
     public function createVerificationSession() {
         if (!wp_verify_nonce($_POST['nonce'], 'gms_guest_nonce')) {
             wp_send_json_error('Security check failed');


### PR DESCRIPTION
## Summary
- add a guest details step to the portal checklist with form validation and gating for later tasks
- persist contact information through a new AJAX endpoint that refreshes agreement content and guest records
- update shared guest portal JavaScript to manage the new contact workflow alongside agreement and verification steps

## Testing
- php -l includes/class-guest-portal.php

------
https://chatgpt.com/codex/tasks/task_e_68e3419751888324b88de2bf846038bd