### PR TITLE
Enhance reservation admin layout

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,9 +1,20 @@
 /**
  * File: admin.css
  * Location: /wp-content/plugins/guest-management-system/assets/css/admin.css
- * 
+ *
  * Admin Styles for Guest Management System
  */
+
+:root {
+    --gms-admin-surface: #ffffff;
+    --gms-admin-border: rgba(148, 163, 184, 0.35);
+    --gms-admin-muted: #4b5563;
+    --gms-admin-accent: #1d4ed8;
+    --gms-admin-accent-soft: rgba(29, 78, 216, 0.12);
+    --gms-admin-soft-bg: #f8fafc;
+    --gms-admin-radius: 14px;
+    --gms-admin-shadow: 0 22px 48px rgba(15, 23, 42, 0.12);
+}
 
 /* Dashboard Stats */
 .gms-dashboard-stats {
@@ -314,6 +325,1021 @@
 
 .gms-reservation-form .button + .button {
     margin-left: 8px;
+}
+
+/* Reservation Detail Layout */
+.gms-reservation-detail {
+    max-width: 1200px;
+    margin-top: 24px;
+}
+
+.gms-reservation-hero {
+    position: relative;
+    display: grid;
+    gap: 24px;
+    padding: 32px;
+    margin: 24px 0 36px;
+    border-radius: calc(var(--gms-admin-radius) + 2px);
+    background: linear-gradient(135deg, #1d4ed8, #0ea5e9);
+    color: #fff;
+    box-shadow: var(--gms-admin-shadow);
+    overflow: hidden;
+}
+
+.gms-reservation-hero::after {
+    content: '';
+    position: absolute;
+    inset: -60px;
+    background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0) 62%);
+    pointer-events: none;
+}
+
+.gms-reservation-hero__intro {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 420px;
+}
+
+.gms-reservation-hero__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+    margin: 0;
+}
+
+.gms-reservation-hero__headline {
+    margin: 0;
+    font-size: 26px;
+    line-height: 1.25;
+    color: #fff;
+}
+
+.gms-reservation-hero__copy {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+.gms-reservation-hero__countdown {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.28);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: #fff;
+}
+
+.gms-reservation-hero__cards {
+    position: relative;
+    z-index: 1;
+}
+
+.gms-reservation-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    margin: 0 0 32px;
+    padding: 20px 24px;
+    border-radius: var(--gms-admin-radius);
+    background: var(--gms-admin-surface);
+    border: 1px solid var(--gms-admin-border);
+    box-shadow: var(--gms-admin-shadow);
+}
+
+.gms-reservation-toolbar__nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.gms-reservation-toolbar__step {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 18px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: var(--gms-admin-soft-bg);
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    min-width: 180px;
+}
+
+.gms-reservation-toolbar__step:hover,
+.gms-reservation-toolbar__step:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 32px rgba(15, 23, 42, 0.12);
+    border-color: rgba(148, 163, 184, 0.6);
+    outline: none;
+}
+
+.gms-reservation-toolbar__step-index {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 12px;
+    background: rgba(148, 163, 184, 0.22);
+    color: #1f2937;
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.gms-reservation-toolbar__step-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.gms-reservation-toolbar__step-label {
+    font-weight: 600;
+    font-size: 14px;
+    color: #0f172a;
+}
+
+.gms-reservation-toolbar__step-status {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--gms-admin-muted);
+}
+
+.gms-reservation-toolbar__step--complete .gms-reservation-toolbar__step-index {
+    background: rgba(34, 197, 94, 0.18);
+    color: #166534;
+}
+
+.gms-reservation-toolbar__step--due .gms-reservation-toolbar__step-index {
+    background: rgba(249, 115, 22, 0.2);
+    color: #7c2d12;
+}
+
+.gms-reservation-toolbar__step--upcoming .gms-reservation-toolbar__step-index {
+    background: rgba(56, 189, 248, 0.22);
+    color: #0c4a6e;
+}
+
+.gms-reservation-toolbar__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+}
+
+.gms-reservation-toolbar__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid var(--gms-admin-border);
+    background: var(--gms-admin-soft-bg);
+    color: #0f172a;
+    font-weight: 600;
+    font-size: 13px;
+    font-family: inherit;
+    line-height: 1.2;
+    text-decoration: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.gms-reservation-toolbar__pill-label {
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--gms-admin-muted);
+}
+
+.gms-reservation-toolbar__pill-value {
+    font-size: 14px;
+    color: #0f172a;
+}
+
+.gms-reservation-toolbar__pill--interactive {
+    cursor: pointer;
+    background: #eff6ff;
+    border-color: rgba(59, 130, 246, 0.35);
+}
+
+.gms-reservation-toolbar__pill--interactive:hover,
+.gms-reservation-toolbar__pill--interactive:focus {
+    background: #dbeafe;
+    border-color: rgba(37, 99, 235, 0.45);
+    outline: none;
+}
+
+.gms-reservation-toolbar__pill--action {
+    background: #1d4ed8;
+    color: #fff;
+    border-color: transparent;
+}
+
+.gms-reservation-toolbar__pill--action:hover,
+.gms-reservation-toolbar__pill--action:focus {
+    background: #1e40af;
+    color: #fff;
+}
+
+.gms-reservation-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    margin: 0;
+}
+
+.gms-reservation-overview__item {
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    border-radius: 12px;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    box-shadow: 0 22px 44px rgba(15, 23, 42, 0.16);
+    backdrop-filter: blur(8px);
+}
+
+.gms-reservation-overview__label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(15, 23, 42, 0.68);
+}
+
+.gms-reservation-overview__value {
+    font-size: 17px;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.gms-reservation-overview__meta {
+    font-size: 13px;
+    color: #1e293b;
+}
+
+.gms-reservation-overview__badge {
+    align-self: flex-start;
+    background: rgba(34, 197, 94, 0.16);
+    color: #166534;
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.gms-reservation-overview__link {
+    font-size: 13px;
+    color: #0f172a;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.gms-reservation-overview__link:hover {
+    text-decoration: underline;
+}
+
+.gms-reservation-detail__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.8fr) minmax(320px, 1fr) minmax(260px, 0.9fr);
+    gap: 28px;
+    align-items: flex-start;
+}
+
+.gms-reservation-detail__timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.gms-reservation-step {
+    position: relative;
+    background: var(--gms-admin-surface);
+    border: 1px solid var(--gms-admin-border);
+    border-top: 6px solid var(--gms-admin-accent);
+    border-radius: var(--gms-admin-radius);
+    padding: 26px;
+    box-shadow: var(--gms-admin-shadow);
+    overflow: hidden;
+}
+
+.gms-reservation-step--complete {
+    border-top-color: #22c55e;
+}
+
+.gms-reservation-step--due {
+    border-top-color: #f97316;
+}
+
+.gms-reservation-step--upcoming {
+    border-top-color: #38bdf8;
+}
+
+.gms-reservation-step--complete .gms-reservation-step__icon {
+    background: rgba(34, 197, 94, 0.18);
+    color: #166534;
+    box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.35);
+}
+
+.gms-reservation-step--due .gms-reservation-step__icon {
+    background: rgba(249, 115, 22, 0.18);
+    color: #7c2d12;
+    box-shadow: inset 0 0 0 1px rgba(249, 115, 22, 0.35);
+}
+
+.gms-reservation-step--upcoming .gms-reservation-step__icon {
+    background: rgba(56, 189, 248, 0.18);
+    color: #0c4a6e;
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.35);
+}
+
+.gms-reservation-step__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 18px;
+}
+
+.gms-reservation-step__title {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.gms-reservation-step__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    background: rgba(148, 163, 184, 0.22);
+    color: #1f2937;
+    font-weight: 600;
+    font-size: 16px;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+.gms-reservation-step__number {
+    line-height: 1;
+}
+
+.gms-reservation-step__header h2 {
+    margin: 0 0 4px;
+    font-size: 20px;
+    color: #0f172a;
+}
+
+.gms-reservation-step__header p {
+    margin: 0;
+    color: var(--gms-admin-muted);
+    line-height: 1.6;
+}
+
+.gms-reservation-step__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 220px;
+    align-items: flex-end;
+    color: var(--gms-admin-muted);
+    font-size: 13px;
+}
+
+.gms-status-badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    color: #0f172a;
+}
+
+.gms-status-badge.is-complete {
+    background: rgba(34, 197, 94, 0.18);
+    color: #166534;
+}
+
+.gms-status-badge.is-due {
+    background: rgba(249, 115, 22, 0.18);
+    color: #7c2d12;
+}
+
+.gms-status-badge.is-upcoming {
+    background: rgba(56, 189, 248, 0.18);
+    color: #0c4a6e;
+}
+
+.gms-reservation-step__schedule,
+.gms-reservation-step__timestamp {
+    font-size: 13px;
+    color: var(--gms-admin-muted);
+}
+
+.gms-reservation-step__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr);
+    gap: 24px;
+    align-items: flex-start;
+}
+
+.gms-reservation-step__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.gms-reservation-step__form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    margin: 0;
+}
+
+.gms-reservation-step__hint {
+    font-size: 12px;
+    color: var(--gms-admin-muted);
+}
+
+.gms-step-feedback {
+    border-radius: 12px;
+    padding: 14px 16px;
+    font-size: 13px;
+    margin: 0;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+    background: rgba(248, 250, 252, 0.8);
+}
+
+.gms-step-feedback ul {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.gms-step-feedback.is-success {
+    background: rgba(220, 252, 231, 0.9);
+    border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.gms-step-feedback.is-warning {
+    background: rgba(254, 243, 199, 0.9);
+    border: 1px solid rgba(251, 191, 36, 0.35);
+}
+
+.gms-step-feedback.is-error {
+    background: rgba(254, 226, 226, 0.9);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.gms-reservation-step__history {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    background: var(--gms-admin-soft-bg);
+    border-radius: calc(var(--gms-admin-radius) - 4px);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    padding: 18px 20px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.gms-reservation-step__history-title {
+    margin: 0;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.gms-reservation-timeline {
+    position: relative;
+    list-style: none;
+    margin: 0;
+    padding: 4px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.gms-reservation-timeline::before {
+    content: '';
+    position: absolute;
+    left: 20px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: rgba(148, 163, 184, 0.45);
+}
+
+.gms-reservation-timeline__item {
+    position: relative;
+    margin: 0;
+    background: #fff;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 12px;
+    padding: 12px 16px 12px 52px;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+}
+
+.gms-reservation-timeline__item::before {
+    content: '';
+    position: absolute;
+    left: 13px;
+    top: 18px;
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--gms-admin-accent);
+    box-shadow: 0 0 0 5px var(--gms-admin-accent-soft);
+}
+
+.gms-reservation-timeline__type {
+    font-weight: 600;
+    font-size: 13px;
+    color: #0f172a;
+}
+
+.gms-reservation-timeline__timestamp {
+    font-size: 12px;
+    color: var(--gms-admin-muted);
+}
+
+.gms-reservation-timeline__summary {
+    font-size: 13px;
+    color: #1f2937;
+}
+
+.gms-reservation-timeline__separator {
+    margin: 0 6px;
+    color: rgba(148, 163, 184, 0.8);
+}
+
+.gms-reservation-step__empty {
+    margin: 0;
+    font-size: 13px;
+    color: #475569;
+    padding: 14px 16px;
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.85);
+}
+
+.gms-panel {
+    background: var(--gms-admin-surface);
+    border: 1px solid var(--gms-admin-border);
+    border-radius: var(--gms-admin-radius);
+    padding: 24px;
+    box-shadow: var(--gms-admin-shadow);
+}
+
+.gms-panel h2 {
+    margin-top: 0;
+    font-size: 20px;
+    color: #0f172a;
+}
+
+.gms-contact-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.gms-contact-panel__intro {
+    margin: 12px 0 18px;
+    font-size: 13px;
+    color: var(--gms-admin-muted);
+}
+
+.gms-contact-panel__list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.gms-contact-panel__item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.gms-contact-panel__item dt {
+    margin: 0;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--gms-admin-muted);
+}
+
+.gms-contact-panel__item dd {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #0f172a;
+    text-align: right;
+}
+
+.gms-contact-panel__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(34, 197, 94, 0.18);
+    color: #166534;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.gms-contact-panel__meta {
+    display: block;
+    font-size: 12px;
+    color: var(--gms-admin-muted);
+    font-weight: 500;
+}
+
+.gms-contact-panel__muted {
+    color: rgba(100, 116, 139, 0.85);
+    font-weight: 500;
+}
+
+.gms-reservation-detail__activity {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.gms-activity-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.gms-activity-panel__count {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--gms-admin-muted);
+}
+
+.gms-activity-panel__intro,
+.gms-activity-panel__meta,
+.gms-activity-panel__hint {
+    font-size: 13px;
+    color: var(--gms-admin-muted);
+    margin: 0 0 10px;
+}
+
+.gms-activity-panel__meta {
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.gms-activity-panel__hint {
+    margin-top: 12px;
+    font-style: italic;
+}
+
+.gms-reservation-timeline--activity {
+    max-height: 420px;
+    overflow: auto;
+    padding-right: 8px;
+    margin-top: 16px;
+}
+
+.gms-reservation-timeline--activity::-webkit-scrollbar {
+    width: 6px;
+}
+
+.gms-reservation-timeline--activity::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.5);
+    border-radius: 999px;
+}
+
+.gms-reservation-activity__empty {
+    margin: 0;
+    font-size: 13px;
+    color: #475569;
+    padding: 16px 18px;
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    border-radius: 12px;
+    background: rgba(248, 250, 252, 0.8);
+}
+
+.gms-copy-success {
+    background: rgba(220, 252, 231, 0.9) !important;
+    color: #166534 !important;
+}
+
+.gms-copy-error {
+    background: rgba(254, 226, 226, 0.9) !important;
+    color: #b91c1c !important;
+}
+
+.gms-reservations-sync {
+    margin-bottom: 28px;
+}
+
+.gms-reservations-sync__form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-end;
+}
+
+.gms-reservations-sync__field {
+    display: flex;
+    flex-direction: column;
+    min-width: 200px;
+    gap: 4px;
+}
+
+.gms-reservations-sync__field label {
+    font-weight: 600;
+}
+
+.gms-reservations-sync__actions {
+    margin-left: auto;
+}
+
+.gms-platform-sync__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 8px 16px;
+    margin: 16px 0;
+}
+
+.gms-platform-sync__summary-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.gms-platform-sync__label {
+    font-size: 12px;
+    color: #50575e;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.gms-platform-sync__value {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.gms-platform-sync__value--muted {
+    color: #8c8f94;
+    font-weight: 500;
+}
+
+.gms-platform-sync__form {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.gms-platform-sync__hint {
+    margin: 0;
+    font-size: 12px;
+    color: #50575e;
+}
+
+.gms-platform-sync__snapshot-list {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 12px;
+    color: #50575e;
+}
+
+.gms-platform-sync__snapshot-list li {
+    margin: 4px 0;
+}
+
+.gms-platform-sync__notice-list,
+.gms-platform-sync__notice-errors {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    font-size: 12px;
+}
+
+.gms-platform-sync__notice-errors {
+    color: #b32d2e;
+}
+
+.gms-reservation-detail__form,
+.gms-reservation-detail__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.gms-reservations-index__intro {
+    margin: 8px 0 24px;
+    font-size: 14px;
+    color: var(--gms-admin-muted);
+    max-width: 560px;
+}
+
+.gms-reservations-table {
+    margin-top: 24px;
+    background: var(--gms-admin-surface);
+    border: 1px solid var(--gms-admin-border);
+    border-radius: var(--gms-admin-radius);
+    padding: 20px 24px;
+    box-shadow: var(--gms-admin-shadow);
+}
+
+.gms-reservations-table__form {
+    margin: 0;
+}
+
+.gms-reservations-table .search-box {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    margin: 0 0 16px;
+}
+
+.gms-reservations-table .search-box label {
+    font-weight: 600;
+    color: var(--gms-admin-muted);
+}
+
+.gms-reservations-table .tablenav.top {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 8px;
+}
+
+.gms-reservations-table .tablenav.bottom {
+    display: none;
+}
+
+.gms-reservations-table .wp-list-table {
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.gms-reservations-table .wp-list-table thead th {
+    background: #f8fafc;
+    font-size: 13px;
+    letter-spacing: 0.02em;
+}
+
+.gms-reservations-table .wp-list-table th,
+.gms-reservations-table .wp-list-table td {
+    padding: 14px 16px;
+    vertical-align: middle;
+}
+
+.gms-reservations-table .wp-list-table tbody tr:nth-child(even) {
+    background: #f9fbff;
+}
+
+.gms-reservations-table .wp-list-table tbody tr:hover {
+    background: #edf2ff;
+}
+
+.gms-reservation-form__field input,
+.gms-reservation-form__field select {
+    width: 100%;
+}
+
+@media screen and (max-width: 1280px) {
+    .gms-reservation-detail__grid {
+        grid-template-columns: minmax(0, 1.5fr) minmax(320px, 1fr);
+    }
+
+    .gms-reservation-detail__activity {
+        grid-column: 1 / -1;
+        position: static;
+    }
+}
+
+@media screen and (max-width: 960px) {
+    .gms-reservation-detail__grid {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .gms-reservation-step__layout {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+
+    .gms-reservation-step__history {
+        order: 3;
+    }
+
+    .gms-reservation-step__meta {
+        align-items: flex-start;
+    }
+
+    .gms-reservation-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 16px;
+    }
+
+    .gms-reservation-toolbar__meta {
+        margin-left: 0;
+    }
+
+    .gms-reservation-toolbar__step {
+        width: 100%;
+    }
+}
+
+@media (min-width: 961px) {
+    .gms-reservation-detail__sidebar {
+        position: sticky;
+        top: 96px;
+    }
+}
+
+@media (min-width: 1281px) {
+    .gms-reservation-detail__activity {
+        position: sticky;
+        top: 96px;
+    }
+}
+
+@media screen and (max-width: 782px) {
+    .gms-reservation-hero {
+        padding: 24px;
+        gap: 20px;
+    }
+
+    .gms-reservation-hero__headline {
+        font-size: 22px;
+    }
+
+    .gms-reservation-hero__countdown {
+        padding: 6px 14px;
+    }
+
+    .gms-reservation-toolbar__nav {
+        flex-direction: column;
+    }
+
+    .gms-reservation-toolbar__step {
+        min-width: 0;
+    }
+
+    .gms-reservations-sync__form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .gms-reservations-sync__actions {
+        margin-left: 0;
+    }
+
+    .gms-platform-sync__form {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .gms-reservations-table {
+        padding: 16px;
+    }
+
+    .gms-reservations-table .search-box {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
 }
 
 /* Character Counter */

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -335,6 +335,24 @@
             });
         });
 
+        $(document).on('click', '.gms-copy-trigger', function(e) {
+            e.preventDefault();
+
+            var $trigger = $(this);
+            var value = $trigger.data('copy-value');
+
+            if (!value) {
+                return;
+            }
+
+            var successMessage = $trigger.data('copy-success') || getString('copySuccess', 'Copied to clipboard.');
+            var errorMessage = $trigger.data('copy-error') || getString('copyError', 'Unable to copy.');
+
+            copyTextToClipboard(value).done(function(success) {
+                showCopyFeedback($trigger, success ? successMessage : errorMessage, !success);
+            });
+        });
+
         $(document).on('click', '.gms-reservation-toggle', function(e) {
             e.preventDefault();
 

--- a/guest-management-system.php
+++ b/guest-management-system.php
@@ -81,6 +81,8 @@ class GuestManagementSystem {
             'class-guest-portal.php',
             'class-email-handler.php',
             'class-sms-handler.php',
+            'class-ota-reservation-sync.php',
+            'class-ota-messaging-handler.php',
             'class-stripe-integration.php',
             'class-ajax-handler.php',
             'class-agreement-handler.php', // Load the new agreement handler class
@@ -120,6 +122,9 @@ class GuestManagementSystem {
             'gms_voipms_user' => '',
             'gms_voipms_pass' => '',
             'gms_voipms_did' => '',
+            'gms_airbnb_access_token' => '',
+            'gms_vrbo_access_token' => '',
+            'gms_booking_access_token' => '',
             'gms_email_from' => get_option('admin_email'),
             'gms_email_from_name' => get_option('blogname'),
             'gms_agreement_template' => $this->getDefaultAgreementTemplate(),

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1203,6 +1203,18 @@ class GMS_Admin {
             'gms_voipms_user' => array('label' => __('VoIP.ms Username', 'guest-management-system')),
             'gms_voipms_pass' => array('label' => __('VoIP.ms API Password', 'guest-management-system')),
             'gms_voipms_did' => array('label' => __('VoIP.ms SMS DID', 'guest-management-system')),
+            'gms_airbnb_access_token' => array(
+                'label' => __('Airbnb Messaging Token', 'guest-management-system'),
+                'description' => __('Required to send reservation updates directly to Airbnb inboxes.', 'guest-management-system'),
+            ),
+            'gms_vrbo_access_token' => array(
+                'label' => __('VRBO Messaging Token', 'guest-management-system'),
+                'description' => __('Enable VRBO in-app messaging when guest contact details are hidden.', 'guest-management-system'),
+            ),
+            'gms_booking_access_token' => array(
+                'label' => __('Booking.com Messaging Token', 'guest-management-system'),
+                'description' => __('Used for posting messages to Booking.com guest conversations.', 'guest-management-system'),
+            ),
             'gms_bitly_token' => array('label' => __('Bitly Access Token', 'guest-management-system')),
             'gms_webhook_token' => array('label' => __('Webhook Shared Secret', 'guest-management-system'))
         );
@@ -1663,7 +1675,7 @@ class GMS_Admin {
      * Render contextual guidance for integrations, including webhook endpoints
      */
     public function render_integrations_help() {
-        echo '<p>' . esc_html__('Provide credentials for payment processing, SMS delivery, URL shortening, and webhook security.', 'guest-management-system') . '</p>';
+        echo '<p>' . esc_html__('Provide credentials for payment processing, SMS delivery, OTA inbox messaging, URL shortening, and webhook security.', 'guest-management-system') . '</p>';
 
         $webhook_urls = function_exists('gms_get_webhook_urls') ? gms_get_webhook_urls() : array();
 
@@ -1691,6 +1703,8 @@ class GMS_Admin {
         echo '</ul>';
         echo '<p>' . esc_html__('Authenticate webhook requests by sending the shared secret saved below as the X-Webhook-Token header or as a webhook_token query parameter.', 'guest-management-system') . '</p>';
         echo '</div>';
+
+        echo '<p class="description">' . esc_html__('Add the Airbnb, VRBO, and Booking.com messaging tokens above to unlock automated OTA conversations when guest contact details are hidden.', 'guest-management-system') . '</p>';
     }
     
     public function add_admin_menu() {
@@ -2014,6 +2028,15 @@ class GMS_Admin {
     }
     
     public function render_reservations_page() {
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $post_action = isset($_POST['gms_action']) ? sanitize_key(wp_unslash($_POST['gms_action'])) : '';
+
+            if ($post_action === 'sync_platform_reservations') {
+                $this->handle_platform_sync_request();
+                return;
+            }
+        }
+
         $action = isset($_GET['action']) ? sanitize_key(wp_unslash($_GET['action'])) : '';
 
         if ($action === 'new') {
@@ -2078,10 +2101,74 @@ class GMS_Admin {
         );
 
         ?>
-        <div class="wrap">
+        <div class="wrap gms-reservations-index">
             <h1 class="wp-heading-inline">Reservations</h1>
             <a href="<?php echo esc_url($add_new_url); ?>" class="page-title-action"><?php esc_html_e('Add New', 'guest-management-system'); ?></a>
             <hr class="wp-header-end">
+
+            <p class="gms-reservations-index__intro"><?php esc_html_e('Centralize every reservation across your connected platforms.', 'guest-management-system'); ?></p>
+
+            <?php
+            $platform_sync_notice = $this->consume_platform_sync_notice();
+            if ($platform_sync_notice) {
+                $this->render_platform_sync_notice($platform_sync_notice);
+            }
+
+            $platform_configs = array();
+            if (class_exists('GMS_OTA_Reservation_Sync')) {
+                $platform_sync_handler = new GMS_OTA_Reservation_Sync();
+                $platform_configs = $platform_sync_handler->get_platform_config();
+            } else {
+                /**
+                 * Fallback configuration for OTA platforms when the sync handler is not available.
+                 *
+                 * @param array $config Default OTA configuration values.
+                 */
+                $platform_configs = apply_filters('gms_ota_reservation_config', array());
+            }
+
+            if (empty($platform_configs)) {
+                $platform_configs = array(
+                    'airbnb' => array('label' => __('Airbnb', 'guest-management-system')),
+                    'vrbo' => array('label' => __('VRBO', 'guest-management-system')),
+                    'booking_com' => array('label' => __('Booking.com', 'guest-management-system')),
+                );
+            }
+
+            if (!empty($platform_configs)) :
+                ?>
+                <div class="gms-panel gms-reservations-sync">
+                    <h2><?php esc_html_e('Sync Platform Reservations', 'guest-management-system'); ?></h2>
+                    <p><?php esc_html_e('Import the latest reservations from connected platforms so you can manage every stay here.', 'guest-management-system'); ?></p>
+                    <form method="post" class="gms-reservations-sync__form">
+                        <?php wp_nonce_field('gms_sync_platform_reservations'); ?>
+                        <input type="hidden" name="gms_action" value="sync_platform_reservations">
+                        <div class="gms-reservations-sync__field">
+                            <label for="gms_sync_platform"><?php esc_html_e('Platform', 'guest-management-system'); ?></label>
+                            <select name="gms_sync_platform" id="gms_sync_platform">
+                                <option value="all"><?php esc_html_e('All Connected Platforms', 'guest-management-system'); ?></option>
+                                <?php foreach ($platform_configs as $platform_key => $platform_settings) :
+                                    $label = isset($platform_settings['label']) ? $platform_settings['label'] : ucfirst(str_replace('_', ' ', $platform_key));
+                                    ?>
+                                    <option value="<?php echo esc_attr($platform_key); ?>"><?php echo esc_html($label); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="gms-reservations-sync__field">
+                            <label for="gms_sync_since"><?php esc_html_e('Updated Since', 'guest-management-system'); ?></label>
+                            <input type="date" name="gms_sync_since" id="gms_sync_since" value="">
+                        </div>
+                        <div class="gms-reservations-sync__field">
+                            <label for="gms_sync_limit"><?php esc_html_e('Limit', 'guest-management-system'); ?></label>
+                            <input type="number" name="gms_sync_limit" id="gms_sync_limit" min="1" max="200" value="50">
+                            <p class="description"><?php esc_html_e('Optional cap to keep the import focused on recent reservations.', 'guest-management-system'); ?></p>
+                        </div>
+                        <div class="gms-reservations-sync__actions">
+                            <button type="submit" class="button button-secondary"><?php esc_html_e('Sync Reservations', 'guest-management-system'); ?></button>
+                        </div>
+                    </form>
+                </div>
+            <?php endif; ?>
 
             <?php if (isset($_GET['gms_reservation_created'])) : ?>
                 <div class="notice notice-success is-dismissible">
@@ -2112,11 +2199,13 @@ class GMS_Admin {
                 </div>
             <?php endif; ?>
 
-            <form method="get">
-                <input type="hidden" name="page" value="guest-management-reservations" />
-                <?php $reservations_table->search_box(__('Search Reservations', 'guest-management-system'), 'gms-reservations'); ?>
-                <?php $reservations_table->display(); ?>
-            </form>
+            <div class="gms-reservations-table">
+                <form method="get" class="gms-reservations-table__form">
+                    <input type="hidden" name="page" value="guest-management-reservations" />
+                    <?php $reservations_table->search_box(__('Search Reservations', 'guest-management-system'), 'gms-reservations'); ?>
+                    <?php $reservations_table->display(); ?>
+                </form>
+            </div>
         </div>
         <?php
     }
@@ -2384,30 +2473,13 @@ class GMS_Admin {
             return;
         }
 
-        $original_door_code = isset($reservation['door_code']) ? (string) $reservation['door_code'] : '';
-
-
         $list_url = add_query_arg(array('page' => 'guest-management-reservations'), admin_url('admin.php'));
 
-
-        $form_values = array(
-            'guest_name' => isset($reservation['guest_name']) ? $reservation['guest_name'] : '',
-            'guest_email' => isset($reservation['guest_email']) ? $reservation['guest_email'] : '',
-            'guest_phone' => isset($reservation['guest_phone']) ? $reservation['guest_phone'] : '',
-            'property_name' => isset($reservation['property_name']) ? $reservation['property_name'] : '',
-            'property_id' => isset($reservation['property_id']) ? $reservation['property_id'] : '',
-            'booking_reference' => isset($reservation['booking_reference']) ? $reservation['booking_reference'] : '',
-            'door_code' => isset($reservation['door_code']) ? $reservation['door_code'] : '',
-            'checkin_date' => $this->format_datetime_for_input(isset($reservation['checkin_date']) ? $reservation['checkin_date'] : ''),
-            'checkout_date' => $this->format_datetime_for_input(isset($reservation['checkout_date']) ? $reservation['checkout_date'] : ''),
-            'status' => isset($reservation['status']) ? $reservation['status'] : 'pending',
-        );
+        $form_values = $this->map_reservation_to_form_values($reservation);
+        $original_door_code = isset($reservation['door_code']) ? (string) $reservation['door_code'] : '';
 
         $errors = array();
-
-
         $success_notice = '';
-
 
         $status_options = function_exists('gms_get_reservation_status_options')
             ? gms_get_reservation_status_options()
@@ -2420,161 +2492,314 @@ class GMS_Admin {
                 'cancelled' => __('Cancelled', 'guest-management-system'),
             );
 
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            check_admin_referer('gms_edit_reservation_' . $reservation_id);
+        $step_feedback = array(
+            'portal' => array('type' => '', 'messages' => array()),
+            'door_code' => array('type' => '', 'messages' => array()),
+            'welcome' => array('type' => '', 'messages' => array()),
+        );
 
+        $platform_refresh_feedback = array('type' => '', 'messages' => array());
+
+        $manual_action_processed = false;
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $action = isset($_POST['gms_action']) ? sanitize_key(wp_unslash($_POST['gms_action'])) : '';
             $posted_id = isset($_POST['reservation_id']) ? absint(wp_unslash($_POST['reservation_id'])) : 0;
 
-            if ($posted_id !== $reservation_id) {
-                $errors[] = __('Invalid reservation request. Please try again.', 'guest-management-system');
-            }
-
-            $fields = array_keys($form_values);
-
-            foreach ($fields as $field) {
-                if (!isset($_POST[$field])) {
-                    $form_values[$field] = '';
-                    continue;
-                }
-
-                $value = wp_unslash($_POST[$field]);
-
-                switch ($field) {
-                    case 'guest_email':
-                        $form_values[$field] = sanitize_email($value);
-                        break;
-                    case 'door_code':
-                        $form_values[$field] = GMS_Database::sanitizeDoorCode($value);
-                        break;
-                    case 'checkin_date':
-                    case 'checkout_date':
-                        $form_values[$field] = $this->format_datetime_for_input($value);
-                        break;
-                    default:
-                        $form_values[$field] = sanitize_text_field($value);
-                        break;
-                }
-            }
-
-            if (empty($form_values['guest_name'])) {
-                $errors[] = __('Guest name is required.', 'guest-management-system');
-            }
-
-            if ($form_values['guest_email'] !== '' && !is_email($form_values['guest_email'])) {
-                $errors[] = __('Please enter a valid email address.', 'guest-management-system');
-            }
-
-            if ($form_values['door_code'] !== '' && !preg_match('/^\d{4}$/', $form_values['door_code'])) {
-                $errors[] = __('Door code must be a 4-digit number.', 'guest-management-system');
-            }
-
-            $allowed_statuses = array_keys($status_options);
-            if (!in_array($form_values['status'], $allowed_statuses, true)) {
-                $form_values['status'] = 'pending';
-            }
-
-            if (empty($errors)) {
-                $normalized_name = trim(sanitize_text_field($form_values['guest_name']));
-                $normalized_email = sanitize_email($form_values['guest_email']);
-                $normalized_phone = $form_values['guest_phone'];
-
-                if (function_exists('gms_sanitize_phone')) {
-                    $normalized_phone = gms_sanitize_phone($normalized_phone);
-                } else {
-                    $normalized_phone = sanitize_text_field($normalized_phone);
-                }
-
-                $form_values['guest_name'] = $normalized_name;
-                $form_values['guest_email'] = $normalized_email;
-                $form_values['guest_phone'] = $normalized_phone;
-
-                $guest_record_id = GMS_Database::upsert_guest(array(
-                    'name' => $form_values['guest_name'],
-                    'email' => $form_values['guest_email'],
-                    'phone' => $form_values['guest_phone'],
-                ), array(
-                    'force_user_creation' => !empty($form_values['guest_email']) && is_email($form_values['guest_email']),
-                ));
-
-                if ($guest_record_id <= 0) {
-                    $errors[] = __('Unable to save guest details. Please try again.', 'guest-management-system');
-                } else {
-                    $guest_id = GMS_Database::ensure_guest_user($guest_record_id, array(
-                        'full_name' => $form_values['guest_name'],
-                        'email' => $form_values['guest_email'],
-                        'phone' => $form_values['guest_phone'],
-                    ), !empty($form_values['guest_email']) && is_email($form_values['guest_email']));
-
-                    $update_data = array(
-                        'guest_id' => $guest_id,
-                        'guest_record_id' => $guest_record_id,
-                        'guest_name' => $form_values['guest_name'],
-                        'guest_email' => $form_values['guest_email'],
-                        'guest_phone' => $form_values['guest_phone'],
-                        'property_name' => $form_values['property_name'],
-                        'property_id' => $form_values['property_id'],
-                        'booking_reference' => $form_values['booking_reference'],
-                        'door_code' => $form_values['door_code'],
-                        'checkin_date' => $this->format_datetime_for_database($form_values['checkin_date']),
-                        'checkout_date' => $this->format_datetime_for_database($form_values['checkout_date']),
-                        'status' => $form_values['status'],
-                    );
-
-                    $updated = GMS_Database::updateReservation($reservation_id, $update_data);
-
-                    if ($updated) {
-                        $door_code_changed = ($form_values['door_code'] !== $original_door_code);
-
-                        if ($door_code_changed && $form_values['door_code'] !== '') {
-                            $reservation_for_sms = GMS_Database::getReservationById($reservation_id);
-                            if ($reservation_for_sms) {
-                                $sms_handler = new GMS_SMS_Handler();
-                                $sms_handler->sendDoorCodeSMS($reservation_for_sms, $form_values['door_code']);
-                            }
-                        }
-
-                        $original_door_code = $form_values['door_code'];
-
-                        $redirect_url = add_query_arg(
-                            array(
-                                'page' => 'guest-management-reservations',
-                                'action' => 'edit',
-                                'reservation_id' => $reservation_id,
-
-                                'gms_reservation_updated' => 1,
-                            ),
-                            admin_url('admin.php')
-                        );
-
-
-                        $redirected = false;
-
-                        if (!headers_sent()) {
-                            $redirected = wp_safe_redirect($redirect_url);
-                        }
-
-                        if ($redirected) {
-                            exit;
-                        }
-
-                        $success_notice = sprintf(
-                            /* translators: 1: opening anchor tag, 2: closing anchor tag */
-                            __('Reservation updated successfully. %1$sReturn to Reservations%2$s.', 'guest-management-system'),
-                            '<a href="' . esc_url($list_url) . '">',
-                            '</a>'
+            if (in_array($action, array('send_portal_link', 'send_door_code_bundle', 'send_welcome_sequence', 'refresh_platform_reservation'), true)) {
+                if ($posted_id !== $reservation_id) {
+                    if ($action === 'refresh_platform_reservation') {
+                        $platform_refresh_feedback = array(
+                            'type' => 'error',
+                            'messages' => array(__('Invalid reservation request. Please refresh and try again.', 'guest-management-system')),
                         );
                     } else {
-                        $errors[] = __('Unable to update reservation. Please try again.', 'guest-management-system');
+                        $step_feedback_key = $action === 'send_portal_link' ? 'portal' : ($action === 'send_door_code_bundle' ? 'door_code' : 'welcome');
+                        $step_feedback[$step_feedback_key] = array(
+                            'type' => 'error',
+                            'messages' => array(__('Invalid reservation request. Please refresh and try again.', 'guest-management-system')),
+                        );
+                    }
+                } else {
+                    $manual_action_processed = true;
+
+                    switch ($action) {
+                        case 'send_portal_link':
+                            check_admin_referer('gms_send_portal_link_' . $reservation_id);
+                            $step_feedback['portal'] = $this->trigger_portal_link_delivery($reservation_id);
+                            break;
+
+                        case 'send_door_code_bundle':
+                            check_admin_referer('gms_send_door_code_' . $reservation_id);
+                            $step_feedback['door_code'] = $this->trigger_door_code_delivery($reservation_id);
+                            break;
+
+                        case 'send_welcome_sequence':
+                            check_admin_referer('gms_send_welcome_' . $reservation_id);
+                            $step_feedback['welcome'] = $this->trigger_welcome_delivery($reservation_id);
+                            break;
+                        case 'refresh_platform_reservation':
+                            check_admin_referer('gms_refresh_platform_' . $reservation_id);
+                            $platform_refresh_feedback = $this->refresh_reservation_from_platform($reservation);
+                            break;
+                    }
+                }
+            }
+
+            if (!$manual_action_processed) {
+                check_admin_referer('gms_edit_reservation_' . $reservation_id);
+
+                if ($posted_id !== $reservation_id) {
+                    $errors[] = __('Invalid reservation request. Please try again.', 'guest-management-system');
+                }
+
+                $fields = array_keys($form_values);
+
+                foreach ($fields as $field) {
+                    $value = isset($_POST[$field]) ? wp_unslash($_POST[$field]) : '';
+
+                    switch ($field) {
+                        case 'guest_email':
+                            $form_values[$field] = sanitize_email($value);
+                            break;
+                        case 'door_code':
+                            $form_values[$field] = GMS_Database::sanitizeDoorCode($value);
+                            break;
+                        case 'checkin_date':
+                        case 'checkout_date':
+                            $form_values[$field] = $this->format_datetime_for_input($value);
+                            break;
+                        default:
+                            $form_values[$field] = sanitize_text_field($value);
+                            break;
+                    }
+                }
+
+                if (empty($form_values['guest_name'])) {
+                    $errors[] = __('Guest name is required.', 'guest-management-system');
+                }
+
+                if ($form_values['guest_email'] !== '' && !is_email($form_values['guest_email'])) {
+                    $errors[] = __('Please enter a valid email address.', 'guest-management-system');
+                }
+
+                if ($form_values['door_code'] !== '' && !preg_match('/^\d{4}$/', $form_values['door_code'])) {
+                    $errors[] = __('Door code must be a 4-digit number.', 'guest-management-system');
+                }
+
+                $allowed_statuses = array_keys($status_options);
+                if (!in_array($form_values['status'], $allowed_statuses, true)) {
+                    $form_values['status'] = 'pending';
+                }
+
+                if (empty($errors)) {
+                    $normalized_name = trim(sanitize_text_field($form_values['guest_name']));
+                    $normalized_email = sanitize_email($form_values['guest_email']);
+                    $normalized_phone = $form_values['guest_phone'];
+
+                    if (function_exists('gms_sanitize_phone')) {
+                        $normalized_phone = gms_sanitize_phone($normalized_phone);
+                    } else {
+                        $normalized_phone = sanitize_text_field($normalized_phone);
+                    }
+
+                    $form_values['guest_name'] = $normalized_name;
+                    $form_values['guest_email'] = $normalized_email;
+                    $form_values['guest_phone'] = $normalized_phone;
+
+                    $guest_record_id = GMS_Database::upsert_guest(array(
+                        'name' => $form_values['guest_name'],
+                        'email' => $form_values['guest_email'],
+                        'phone' => $form_values['guest_phone'],
+                    ), array(
+                        'force_user_creation' => !empty($form_values['guest_email']) && is_email($form_values['guest_email']),
+                    ));
+
+                    if ($guest_record_id <= 0) {
+                        $errors[] = __('Unable to save guest details. Please try again.', 'guest-management-system');
+                    } else {
+                        $guest_id = GMS_Database::ensure_guest_user($guest_record_id, array(
+                            'full_name' => $form_values['guest_name'],
+                            'email' => $form_values['guest_email'],
+                            'phone' => $form_values['guest_phone'],
+                        ), !empty($form_values['guest_email']) && is_email($form_values['guest_email']));
+
+                        $update_data = array(
+                            'guest_id' => $guest_id,
+                            'guest_record_id' => $guest_record_id,
+                            'guest_name' => $form_values['guest_name'],
+                            'guest_email' => $form_values['guest_email'],
+                            'guest_phone' => $form_values['guest_phone'],
+                            'property_name' => $form_values['property_name'],
+                            'property_id' => $form_values['property_id'],
+                            'booking_reference' => $form_values['booking_reference'],
+                            'door_code' => $form_values['door_code'],
+                            'checkin_date' => $this->format_datetime_for_database($form_values['checkin_date']),
+                            'checkout_date' => $this->format_datetime_for_database($form_values['checkout_date']),
+                            'status' => $form_values['status'],
+                        );
+
+                        $updated = GMS_Database::updateReservation($reservation_id, $update_data);
+
+                        if ($updated) {
+                            $door_code_changed = ($form_values['door_code'] !== $original_door_code);
+
+                            if ($door_code_changed && $form_values['door_code'] !== '') {
+                                $reservation_for_notifications = GMS_Database::getReservationById($reservation_id);
+
+                                if ($reservation_for_notifications) {
+                                    $sms_handler = new GMS_SMS_Handler();
+                                    $sms_handler->sendDoorCodeSMS($reservation_for_notifications, $form_values['door_code']);
+
+                                    $email_handler = new GMS_Email_Handler();
+                                    $email_handler->sendDoorCodeEmail($reservation_for_notifications, $form_values['door_code']);
+
+                                    $this->log_portal_door_code_update(
+                                        $reservation_id,
+                                        intval($reservation_for_notifications['guest_id'] ?? 0),
+                                        $form_values['door_code']
+                                    );
+                                }
+                            }
+
+                            $reservation = GMS_Database::getReservationById($reservation_id);
+                            if ($reservation) {
+                                $form_values = $this->map_reservation_to_form_values($reservation);
+                                $original_door_code = isset($reservation['door_code']) ? (string) $reservation['door_code'] : '';
+                            }
+
+                            $redirect_url = add_query_arg(
+                                array(
+                                    'page' => 'guest-management-reservations',
+                                    'action' => 'edit',
+                                    'reservation_id' => $reservation_id,
+                                    'gms_reservation_updated' => 1,
+                                ),
+                                admin_url('admin.php')
+                            );
+
+                            $redirected = false;
+
+                            if (!headers_sent()) {
+                                $redirected = wp_safe_redirect($redirect_url);
+                            }
+
+                            if ($redirected) {
+                                exit;
+                            }
+
+                            $success_notice = sprintf(
+                                /* translators: 1: opening anchor tag, 2: closing anchor tag */
+                                __('Reservation updated successfully. %1$sReturn to Reservations%2$s.', 'guest-management-system'),
+                                '<a href="' . esc_url($list_url) . '">',
+                                '</a>'
+                            );
+                        } else {
+                            $errors[] = __('Unable to update reservation. Please try again.', 'guest-management-system');
+                        }
                     }
                 }
             }
         }
 
+        if ($manual_action_processed) {
+            $reservation = GMS_Database::getReservationById($reservation_id);
+            if ($reservation) {
+                $form_values = $this->map_reservation_to_form_values($reservation);
+                $original_door_code = isset($reservation['door_code']) ? (string) $reservation['door_code'] : '';
+            }
+        }
+
+        $communications = GMS_Database::getCommunicationsForReservation($reservation_id, array(
+            'limit' => 150,
+            'order' => 'DESC',
+        ));
+
+        $day_in_seconds = defined('DAY_IN_SECONDS') ? DAY_IN_SECONDS : 86400;
+        $hour_in_seconds = defined('HOUR_IN_SECONDS') ? HOUR_IN_SECONDS : 3600;
+
+        $checkin_timestamp = isset($reservation['checkin_date']) && $reservation['checkin_date'] !== ''
+            ? strtotime($reservation['checkin_date'])
+            : 0;
+
+        $checkout_timestamp = isset($reservation['checkout_date']) && $reservation['checkout_date'] !== ''
+            ? strtotime($reservation['checkout_date'])
+            : 0;
+
+        $portal_schedule_timestamp = $checkin_timestamp ? $checkin_timestamp - (14 * $day_in_seconds) : 0;
+        $door_code_schedule_timestamp = $checkin_timestamp ? $checkin_timestamp - (7 * $day_in_seconds) : 0;
+        $welcome_schedule_timestamp = $checkin_timestamp ? $checkin_timestamp - (2 * $hour_in_seconds) : 0;
+
+        $portal_logs = $this->filter_communications_by_context($communications, array('portal_link_sequence'));
+        $door_code_logs = $this->filter_communications_by_context($communications, array('door_code_sequence'), array('portal_update'));
+        $welcome_logs = $this->filter_communications_by_context($communications, array('welcome_sequence'));
+
+        $activity_total = is_array($communications) ? count($communications) : 0;
+        $activity_logs = $activity_total > 0 ? array_slice($communications, 0, 30) : array();
+        $latest_activity_display = ($activity_total > 0 && isset($communications[0]['sent_at']))
+            ? $this->format_admin_datetime($communications[0]['sent_at'])
+            : '';
+
+        $now = current_time('timestamp');
+
+        $portal_status = $this->determine_step_status($portal_logs, $portal_schedule_timestamp, $now);
+        $door_code_status = $this->determine_step_status($door_code_logs, $door_code_schedule_timestamp, $now);
+        $welcome_status = $this->determine_step_status($welcome_logs, $welcome_schedule_timestamp, $now);
+
+        $portal_status_meta = $this->get_step_status_meta($portal_status);
+        $door_code_status_meta = $this->get_step_status_meta($door_code_status);
+        $welcome_status_meta = $this->get_step_status_meta($welcome_status);
+
+        $portal_schedule_text = $this->format_schedule_description($checkin_timestamp, $portal_schedule_timestamp, __('14 days before check-in', 'guest-management-system'), $now);
+        $door_code_schedule_text = $this->format_schedule_description($checkin_timestamp, $door_code_schedule_timestamp, __('7 days before check-in', 'guest-management-system'), $now);
+        $welcome_schedule_text = $this->format_schedule_description($checkin_timestamp, $welcome_schedule_timestamp, __('2 hours before check-in', 'guest-management-system'), $now);
+
+        $checkin_countdown_text = '';
+        if ($checkin_timestamp) {
+            if ($checkin_timestamp > $now) {
+                $diff = $checkin_timestamp - $now;
+                if ($diff >= $day_in_seconds) {
+                    $days_remaining = (int) ceil($diff / $day_in_seconds);
+                    $checkin_countdown_text = sprintf(
+                        _n('%s day until check-in', '%s days until check-in', $days_remaining, 'guest-management-system'),
+                        number_format_i18n($days_remaining)
+                    );
+                } else {
+                    $hours_remaining = max(1, (int) ceil($diff / $hour_in_seconds));
+                    $checkin_countdown_text = sprintf(
+                        _n('%s hour until check-in', '%s hours until check-in', $hours_remaining, 'guest-management-system'),
+                        number_format_i18n($hours_remaining)
+                    );
+                }
+            } else {
+                if ($checkout_timestamp && $checkout_timestamp > $now) {
+                    $checkin_countdown_text = __('Guest is currently checked in.', 'guest-management-system');
+                } else {
+                    $checkin_countdown_text = __('Stay has ended.', 'guest-management-system');
+                }
+            }
+        }
+
+        $portal_last_sent = !empty($portal_logs) ? $this->format_admin_datetime($portal_logs[0]['sent_at'] ?? '') : '';
+        $door_code_last_sent = !empty($door_code_logs) ? $this->format_admin_datetime($door_code_logs[0]['sent_at'] ?? '') : '';
+        $welcome_last_sent = !empty($welcome_logs) ? $this->format_admin_datetime($welcome_logs[0]['sent_at'] ?? '') : '';
+
+        $portal_url = gms_get_portal_url($reservation_id);
+        $door_code_display = $form_values['door_code'] !== '' ? $form_values['door_code'] : '';
+        $checkin_display = $this->format_admin_datetime($reservation['checkin_date'] ?? '');
+        $checkout_display = $this->format_admin_datetime($reservation['checkout_date'] ?? '');
+        $status_label = isset($status_options[$form_values['status']]) ? $status_options[$form_values['status']] : ucfirst($form_values['status']);
+
+        $platform_key = $this->normalize_platform_key($reservation['platform'] ?? '');
+        $platform_label = $this->describe_platform_label($platform_key);
+        $platform_credentials_ready = $this->platform_credentials_ready($platform_key);
+        $platform_meta = $this->extract_platform_sync_snapshot($reservation, $platform_key);
+        $platform_button_label = $platform_label !== '' ? $platform_label : __('Platform', 'guest-management-system');
+
         $cancel_url = $list_url;
 
-
         ?>
-        <div class="wrap">
+        <div class="wrap gms-reservation-detail">
             <h1 class="wp-heading-inline"><?php esc_html_e('Edit Reservation', 'guest-management-system'); ?></h1>
             <a href="<?php echo esc_url($cancel_url); ?>" class="page-title-action"><?php esc_html_e('Back to Reservations', 'guest-management-system'); ?></a>
             <hr class="wp-header-end">
@@ -2584,7 +2809,6 @@ class GMS_Admin {
                     <p><?php esc_html_e('Reservation updated successfully.', 'guest-management-system'); ?></p>
                 </div>
             <?php endif; ?>
-
 
             <?php if ($success_notice) : ?>
                 <div class="notice notice-success is-dismissible">
@@ -2602,69 +2826,1325 @@ class GMS_Admin {
                 </div>
             <?php endif; ?>
 
-            <form method="post">
-                <?php wp_nonce_field('gms_edit_reservation_' . $reservation_id); ?>
-                <input type="hidden" name="reservation_id" value="<?php echo esc_attr($reservation_id); ?>">
-                <table class="form-table" role="presentation">
-                    <tbody>
-                        <tr>
-                            <th scope="row"><label for="gms_guest_name_edit"><?php esc_html_e('Guest Name', 'guest-management-system'); ?></label></th>
-                            <td><input name="guest_name" type="text" id="gms_guest_name_edit" value="<?php echo esc_attr($form_values['guest_name']); ?>" class="regular-text" required></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_guest_email_edit"><?php esc_html_e('Guest Email', 'guest-management-system'); ?></label></th>
-                            <td><input name="guest_email" type="email" id="gms_guest_email_edit" value="<?php echo esc_attr($form_values['guest_email']); ?>" class="regular-text"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_guest_phone_edit"><?php esc_html_e('Guest Phone', 'guest-management-system'); ?></label></th>
-                            <td><input name="guest_phone" type="text" id="gms_guest_phone_edit" value="<?php echo esc_attr($form_values['guest_phone']); ?>" class="regular-text"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_property_name_edit"><?php esc_html_e('Property Name', 'guest-management-system'); ?></label></th>
-                            <td><input name="property_name" type="text" id="gms_property_name_edit" value="<?php echo esc_attr($form_values['property_name']); ?>" class="regular-text"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_property_id_edit"><?php esc_html_e('Property ID', 'guest-management-system'); ?></label></th>
-                            <td><input name="property_id" type="text" id="gms_property_id_edit" value="<?php echo esc_attr($form_values['property_id']); ?>" class="regular-text"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_booking_reference_edit"><?php esc_html_e('Booking Reference', 'guest-management-system'); ?></label></th>
-                            <td><input name="booking_reference" type="text" id="gms_booking_reference_edit" value="<?php echo esc_attr($form_values['booking_reference']); ?>" class="regular-text"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_door_code_edit"><?php esc_html_e('Door Code', 'guest-management-system'); ?></label></th>
-                            <td>
-                                <input name="door_code" type="text" id="gms_door_code_edit" value="<?php echo esc_attr($form_values['door_code']); ?>" class="regular-text" maxlength="4" pattern="\d{4}" inputmode="numeric">
-                                <p class="description"><?php esc_html_e('Provide the 4-digit entry code for the guest.', 'guest-management-system'); ?></p>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_checkin_date_edit"><?php esc_html_e('Check-in Date', 'guest-management-system'); ?></label></th>
-                            <td><input name="checkin_date" type="datetime-local" id="gms_checkin_date_edit" value="<?php echo esc_attr($form_values['checkin_date']); ?>" class="regular-text"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_checkout_date_edit"><?php esc_html_e('Check-out Date', 'guest-management-system'); ?></label></th>
-                            <td><input name="checkout_date" type="datetime-local" id="gms_checkout_date_edit" value="<?php echo esc_attr($form_values['checkout_date']); ?>" class="regular-text"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="gms_status_edit"><?php esc_html_e('Status', 'guest-management-system'); ?></label></th>
-                            <td>
-                                <select name="status" id="gms_status_edit">
-                                    <?php
-                                    foreach ($status_options as $status_key => $status_label) :
-                                        ?>
-                                        <option value="<?php echo esc_attr($status_key); ?>"<?php selected($form_values['status'], $status_key); ?>><?php echo esc_html($status_label); ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+            <div class="gms-reservation-hero">
+                <div class="gms-reservation-hero__intro">
+                    <p class="gms-reservation-hero__eyebrow"><?php esc_html_e('Guest journey automation', 'guest-management-system'); ?></p>
+                    <h2 class="gms-reservation-hero__headline"><?php esc_html_e('Reservation snapshot', 'guest-management-system'); ?></h2>
+                    <p class="gms-reservation-hero__copy"><?php esc_html_e('Review the stay at a glance and keep each milestone on schedule.', 'guest-management-system'); ?></p>
+                    <?php if ($checkin_countdown_text !== '') : ?>
+                        <span class="gms-reservation-hero__countdown"><?php echo esc_html($checkin_countdown_text); ?></span>
+                    <?php endif; ?>
+                </div>
+                <div class="gms-reservation-hero__cards">
+                    <div class="gms-reservation-overview">
+                        <div class="gms-reservation-overview__item">
+                            <span class="gms-reservation-overview__label"><?php esc_html_e('Guest', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-overview__value"><?php echo esc_html($form_values['guest_name'] !== '' ? $form_values['guest_name'] : __('Unknown Guest', 'guest-management-system')); ?></span>
+                            <?php if ($form_values['guest_email'] !== '') : ?>
+                                <span class="gms-reservation-overview__meta"><?php echo esc_html($form_values['guest_email']); ?></span>
+                            <?php endif; ?>
+                            <?php if ($form_values['guest_phone'] !== '') : ?>
+                                <span class="gms-reservation-overview__meta"><?php echo esc_html($form_values['guest_phone']); ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="gms-reservation-overview__item">
+                            <span class="gms-reservation-overview__label"><?php esc_html_e('Property', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-overview__value"><?php echo esc_html($form_values['property_name'] !== '' ? $form_values['property_name'] : __('Not set', 'guest-management-system')); ?></span>
+                            <?php if ($form_values['booking_reference'] !== '') : ?>
+                                <span class="gms-reservation-overview__meta"><?php printf(esc_html__('Booking Ref: %s', 'guest-management-system'), esc_html($form_values['booking_reference'])); ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="gms-reservation-overview__item">
+                            <span class="gms-reservation-overview__label"><?php esc_html_e('Stay', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-overview__value"><?php echo esc_html($checkin_display !== '' ? $checkin_display : __('Check-in not scheduled', 'guest-management-system')); ?></span>
+                            <?php if ($checkout_display !== '') : ?>
+                                <span class="gms-reservation-overview__meta"><?php echo esc_html(sprintf(__('Check-out: %s', 'guest-management-system'), $checkout_display)); ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="gms-reservation-overview__item">
+                            <span class="gms-reservation-overview__label"><?php esc_html_e('Status', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-overview__badge"><?php echo esc_html($status_label); ?></span>
+                            <?php if ($portal_url) : ?>
+                                <a class="gms-reservation-overview__link" href="<?php echo esc_url($portal_url); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Open guest portal', 'guest-management-system'); ?></a>
+                            <?php else : ?>
+                                <span class="gms-reservation-overview__meta"><?php esc_html_e('Portal link will appear after activation.', 'guest-management-system'); ?></span>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-                <?php submit_button(__('Update Reservation', 'guest-management-system')); ?>
-            </form>
+            <div class="gms-reservation-toolbar" role="navigation" aria-label="<?php esc_attr_e('Reservation workflow shortcuts', 'guest-management-system'); ?>">
+                <div class="gms-reservation-toolbar__nav">
+                    <a class="gms-reservation-toolbar__step gms-reservation-toolbar__step--<?php echo esc_attr($portal_status); ?>" href="#gms-step-portal" aria-label="<?php echo esc_attr(sprintf(__('Jump to portal invitation step. Status: %s.', 'guest-management-system'), $portal_status_meta['label'])); ?>">
+                        <span class="gms-reservation-toolbar__step-index" aria-hidden="true">1</span>
+                        <span class="gms-reservation-toolbar__step-content">
+                            <span class="gms-reservation-toolbar__step-label"><?php esc_html_e('Portal Invite', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-toolbar__step-status"><?php echo esc_html($portal_status_meta['label']); ?></span>
+                        </span>
+                    </a>
+                    <a class="gms-reservation-toolbar__step gms-reservation-toolbar__step--<?php echo esc_attr($door_code_status); ?>" href="#gms-step-door-code" aria-label="<?php echo esc_attr(sprintf(__('Jump to door code delivery step. Status: %s.', 'guest-management-system'), $door_code_status_meta['label'])); ?>">
+                        <span class="gms-reservation-toolbar__step-index" aria-hidden="true">2</span>
+                        <span class="gms-reservation-toolbar__step-content">
+                            <span class="gms-reservation-toolbar__step-label"><?php esc_html_e('Door Code', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-toolbar__step-status"><?php echo esc_html($door_code_status_meta['label']); ?></span>
+                        </span>
+                    </a>
+                    <a class="gms-reservation-toolbar__step gms-reservation-toolbar__step--<?php echo esc_attr($welcome_status); ?>" href="#gms-step-welcome" aria-label="<?php echo esc_attr(sprintf(__('Jump to welcome touchpoint step. Status: %s.', 'guest-management-system'), $welcome_status_meta['label'])); ?>">
+                        <span class="gms-reservation-toolbar__step-index" aria-hidden="true">3</span>
+                        <span class="gms-reservation-toolbar__step-content">
+                            <span class="gms-reservation-toolbar__step-label"><?php esc_html_e('Welcome Touchpoint', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-toolbar__step-status"><?php echo esc_html($welcome_status_meta['label']); ?></span>
+                        </span>
+                    </a>
+                </div>
+                <div class="gms-reservation-toolbar__meta">
+                    <?php if ($checkin_display !== '') : ?>
+                        <span class="gms-reservation-toolbar__pill">
+                            <span class="gms-reservation-toolbar__pill-label"><?php esc_html_e('Check-in', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-toolbar__pill-value"><?php echo esc_html($checkin_display); ?></span>
+                        </span>
+                    <?php endif; ?>
+                    <?php if ($checkout_display !== '') : ?>
+                        <span class="gms-reservation-toolbar__pill">
+                            <span class="gms-reservation-toolbar__pill-label"><?php esc_html_e('Check-out', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-toolbar__pill-value"><?php echo esc_html($checkout_display); ?></span>
+                        </span>
+                    <?php endif; ?>
+                    <?php if ($door_code_display !== '') : ?>
+                        <button type="button" class="gms-reservation-toolbar__pill gms-reservation-toolbar__pill--interactive gms-copy-trigger" data-copy-value="<?php echo esc_attr($door_code_display); ?>" data-copy-success="<?php esc_attr_e('Door code copied to clipboard.', 'guest-management-system'); ?>" data-copy-error="<?php esc_attr_e('Unable to copy door code.', 'guest-management-system'); ?>">
+                            <span class="gms-reservation-toolbar__pill-label"><?php esc_html_e('Door Code', 'guest-management-system'); ?></span>
+                            <span class="gms-reservation-toolbar__pill-value"><?php echo esc_html($door_code_display); ?></span>
+                        </button>
+                    <?php endif; ?>
+                    <?php if ($portal_url) : ?>
+                        <a class="gms-reservation-toolbar__pill gms-reservation-toolbar__pill--action gms-open-portal" href="<?php echo esc_url($portal_url); ?>" target="_blank" rel="noopener noreferrer" data-copy-url="<?php echo esc_attr($portal_url); ?>"><?php esc_html_e('Open Guest Portal', 'guest-management-system'); ?></a>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="gms-reservation-detail__grid">
+                <div class="gms-reservation-detail__timeline">
+                    <section id="gms-step-portal" class="gms-reservation-step gms-reservation-step--<?php echo esc_attr($portal_status); ?>">
+                        <div class="gms-reservation-step__header">
+                            <div class="gms-reservation-step__title">
+                                <span class="gms-reservation-step__icon" aria-hidden="true">
+                                    <span class="gms-reservation-step__number">1</span>
+                                </span>
+                                <div>
+                                    <h2><?php esc_html_e('Guest Portal Invitation', 'guest-management-system'); ?></h2>
+                                    <p><?php esc_html_e('Send the secure guest portal link 14 days before arrival so the guest can complete their tasks.', 'guest-management-system'); ?></p>
+                                </div>
+                            </div>
+                            <div class="gms-reservation-step__meta">
+                                <span class="gms-status-badge <?php echo esc_attr($portal_status_meta['class']); ?>"><?php echo esc_html($portal_status_meta['label']); ?></span>
+                                <span class="gms-reservation-step__schedule"><?php echo esc_html($portal_schedule_text); ?></span>
+                                <?php if ($portal_last_sent !== '') : ?>
+                                    <span class="gms-reservation-step__timestamp"><?php printf(esc_html__('Last activity: %s', 'guest-management-system'), esc_html($portal_last_sent)); ?></span>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <div class="gms-reservation-step__layout">
+                            <div class="gms-reservation-step__actions">
+                                <?php if (!empty($step_feedback['portal']['messages'])) : ?>
+                                    <div class="gms-step-feedback <?php echo esc_attr($this->map_feedback_class($step_feedback['portal']['type'])); ?>">
+                                        <ul>
+                                            <?php foreach ($step_feedback['portal']['messages'] as $message) : ?>
+                                                <li><?php echo esc_html($message); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    </div>
+                                <?php endif; ?>
+
+                                <form method="post" class="gms-reservation-step__form">
+                                    <?php wp_nonce_field('gms_send_portal_link_' . $reservation_id); ?>
+                                    <input type="hidden" name="gms_action" value="send_portal_link">
+                                    <input type="hidden" name="reservation_id" value="<?php echo esc_attr($reservation_id); ?>">
+                                    <button type="submit" class="button button-primary"><?php esc_html_e('Send Portal Link Now', 'guest-management-system'); ?></button>
+                                    <span class="gms-reservation-step__hint"><?php esc_html_e('Delivers email/SMS when contact info is available and posts to connected OTA inboxes.', 'guest-management-system'); ?></span>
+                                </form>
+                            </div>
+                            <div class="gms-reservation-step__history">
+                                <h3 class="gms-reservation-step__history-title"><?php esc_html_e('Portal link activity', 'guest-management-system'); ?></h3>
+                                <?php $this->render_step_timeline($portal_logs); ?>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section id="gms-step-door-code" class="gms-reservation-step gms-reservation-step--<?php echo esc_attr($door_code_status); ?>">
+                        <div class="gms-reservation-step__header">
+                            <div class="gms-reservation-step__title">
+                                <span class="gms-reservation-step__icon" aria-hidden="true">
+                                    <span class="gms-reservation-step__number">2</span>
+                                </span>
+                                <div>
+                                    <h2><?php esc_html_e('Access Code Delivery', 'guest-management-system'); ?></h2>
+                                    <p><?php esc_html_e('Share the door code and sync it to the portal 7 days before check-in.', 'guest-management-system'); ?></p>
+                                </div>
+                            </div>
+                            <div class="gms-reservation-step__meta">
+                                <span class="gms-status-badge <?php echo esc_attr($door_code_status_meta['class']); ?>"><?php echo esc_html($door_code_status_meta['label']); ?></span>
+                                <span class="gms-reservation-step__schedule"><?php echo esc_html($door_code_schedule_text); ?></span>
+                                <?php if ($door_code_last_sent !== '') : ?>
+                                    <span class="gms-reservation-step__timestamp"><?php printf(esc_html__('Last activity: %s', 'guest-management-system'), esc_html($door_code_last_sent)); ?></span>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <div class="gms-reservation-step__layout">
+                            <div class="gms-reservation-step__actions">
+                                <?php if (!empty($step_feedback['door_code']['messages'])) : ?>
+                                    <div class="gms-step-feedback <?php echo esc_attr($this->map_feedback_class($step_feedback['door_code']['type'])); ?>">
+                                        <ul>
+                                            <?php foreach ($step_feedback['door_code']['messages'] as $message) : ?>
+                                                <li><?php echo esc_html($message); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    </div>
+                                <?php endif; ?>
+
+                                <form method="post" class="gms-reservation-step__form">
+                                    <?php wp_nonce_field('gms_send_door_code_' . $reservation_id); ?>
+                                    <input type="hidden" name="gms_action" value="send_door_code_bundle">
+                                    <input type="hidden" name="reservation_id" value="<?php echo esc_attr($reservation_id); ?>">
+                                    <button type="submit" class="button button-primary"><?php esc_html_e('Send Door Code Package', 'guest-management-system'); ?></button>
+                                    <span class="gms-reservation-step__hint"><?php esc_html_e('Sends email, SMS, records a portal update, and posts to OTA inboxes when configured.', 'guest-management-system'); ?></span>
+                                </form>
+                            </div>
+                            <div class="gms-reservation-step__history">
+                                <h3 class="gms-reservation-step__history-title"><?php esc_html_e('Access package activity', 'guest-management-system'); ?></h3>
+                                <?php $this->render_step_timeline($door_code_logs); ?>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section id="gms-step-welcome" class="gms-reservation-step gms-reservation-step--<?php echo esc_attr($welcome_status); ?>">
+                        <div class="gms-reservation-step__header">
+                            <div class="gms-reservation-step__title">
+                                <span class="gms-reservation-step__icon" aria-hidden="true">
+                                    <span class="gms-reservation-step__number">3</span>
+                                </span>
+                                <div>
+                                    <h2><?php esc_html_e('Welcome Touchpoint', 'guest-management-system'); ?></h2>
+                                    <p><?php esc_html_e('Send a warm welcome message two hours before arrival to confirm everything is ready.', 'guest-management-system'); ?></p>
+                                </div>
+                            </div>
+                            <div class="gms-reservation-step__meta">
+                                <span class="gms-status-badge <?php echo esc_attr($welcome_status_meta['class']); ?>"><?php echo esc_html($welcome_status_meta['label']); ?></span>
+                                <span class="gms-reservation-step__schedule"><?php echo esc_html($welcome_schedule_text); ?></span>
+                                <?php if ($welcome_last_sent !== '') : ?>
+                                    <span class="gms-reservation-step__timestamp"><?php printf(esc_html__('Last activity: %s', 'guest-management-system'), esc_html($welcome_last_sent)); ?></span>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <div class="gms-reservation-step__layout">
+                            <div class="gms-reservation-step__actions">
+                                <?php if (!empty($step_feedback['welcome']['messages'])) : ?>
+                                    <div class="gms-step-feedback <?php echo esc_attr($this->map_feedback_class($step_feedback['welcome']['type'])); ?>">
+                                        <ul>
+                                            <?php foreach ($step_feedback['welcome']['messages'] as $message) : ?>
+                                                <li><?php echo esc_html($message); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    </div>
+                                <?php endif; ?>
+
+                                <form method="post" class="gms-reservation-step__form">
+                                    <?php wp_nonce_field('gms_send_welcome_' . $reservation_id); ?>
+                                    <input type="hidden" name="gms_action" value="send_welcome_sequence">
+                                    <input type="hidden" name="reservation_id" value="<?php echo esc_attr($reservation_id); ?>">
+                                    <button type="submit" class="button button-primary"><?php esc_html_e('Send Welcome Message', 'guest-management-system'); ?></button>
+                                    <span class="gms-reservation-step__hint"><?php esc_html_e('Delivers email/SMS greetings and posts to OTA inboxes when configured.', 'guest-management-system'); ?></span>
+                                </form>
+                            </div>
+                            <div class="gms-reservation-step__history">
+                                <h3 class="gms-reservation-step__history-title"><?php esc_html_e('Welcome message activity', 'guest-management-system'); ?></h3>
+                                <?php $this->render_step_timeline($welcome_logs); ?>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+
+                <div class="gms-reservation-detail__form gms-reservation-detail__sidebar">
+                    <div class="gms-panel gms-contact-panel">
+                        <div class="gms-contact-panel__header">
+                            <h2><?php esc_html_e('Guest Directory', 'guest-management-system'); ?></h2>
+                            <?php if ($portal_url) : ?>
+                                <a class="button button-secondary gms-open-portal" href="<?php echo esc_url($portal_url); ?>" target="_blank" rel="noopener noreferrer" data-copy-url="<?php echo esc_attr($portal_url); ?>"><?php esc_html_e('Launch Portal', 'guest-management-system'); ?></a>
+                            <?php endif; ?>
+                        </div>
+                        <p class="gms-contact-panel__intro"><?php esc_html_e('Reach guests instantly and keep reservation essentials handy.', 'guest-management-system'); ?></p>
+                        <dl class="gms-contact-panel__list">
+                            <div class="gms-contact-panel__item">
+                                <dt><?php esc_html_e('Guest', 'guest-management-system'); ?></dt>
+                                <dd><?php echo esc_html($form_values['guest_name'] !== '' ? $form_values['guest_name'] : __('Unknown Guest', 'guest-management-system')); ?></dd>
+                            </div>
+                            <div class="gms-contact-panel__item">
+                                <dt><?php esc_html_e('Email', 'guest-management-system'); ?></dt>
+                                <dd><?php echo $form_values['guest_email'] !== '' ? esc_html($form_values['guest_email']) : '<span class="gms-contact-panel__muted">' . esc_html__('Not provided', 'guest-management-system') . '</span>'; ?></dd>
+                            </div>
+                            <div class="gms-contact-panel__item">
+                                <dt><?php esc_html_e('Phone', 'guest-management-system'); ?></dt>
+                                <dd><?php echo $form_values['guest_phone'] !== '' ? esc_html($form_values['guest_phone']) : '<span class="gms-contact-panel__muted">' . esc_html__('Not provided', 'guest-management-system') . '</span>'; ?></dd>
+                            </div>
+                            <div class="gms-contact-panel__item">
+                                <dt><?php esc_html_e('Property', 'guest-management-system'); ?></dt>
+                                <dd><?php echo esc_html($form_values['property_name'] !== '' ? $form_values['property_name'] : __('Not set', 'guest-management-system')); ?></dd>
+                            </div>
+                            <div class="gms-contact-panel__item">
+                                <dt><?php esc_html_e('Status', 'guest-management-system'); ?></dt>
+                                <dd><span class="gms-contact-panel__badge"><?php echo esc_html($status_label); ?></span></dd>
+                            </div>
+                            <?php if ($door_code_display !== '') : ?>
+                                <div class="gms-contact-panel__item">
+                                    <dt><?php esc_html_e('Door Code', 'guest-management-system'); ?></dt>
+                                    <dd><?php echo esc_html($door_code_display); ?></dd>
+                                </div>
+                            <?php endif; ?>
+                            <?php if ($checkin_display !== '' || $checkout_display !== '') : ?>
+                                <div class="gms-contact-panel__item">
+                                    <dt><?php esc_html_e('Stay Window', 'guest-management-system'); ?></dt>
+                                    <dd>
+                                        <?php if ($checkin_display !== '') : ?>
+                                            <span class="gms-contact-panel__meta"><?php printf(esc_html__('Check-in: %s', 'guest-management-system'), esc_html($checkin_display)); ?></span>
+                                        <?php endif; ?>
+                                        <?php if ($checkout_display !== '') : ?>
+                                            <span class="gms-contact-panel__meta"><?php printf(esc_html__('Check-out: %s', 'guest-management-system'), esc_html($checkout_display)); ?></span>
+                                        <?php endif; ?>
+                                    </dd>
+                                </div>
+                            <?php endif; ?>
+                        </dl>
+                    </div>
+                    <div class="gms-panel gms-platform-panel">
+                        <h2><?php esc_html_e('Platform Reservation', 'guest-management-system'); ?></h2>
+                        <p><?php esc_html_e('Stay aligned with Airbnb, VRBO, and Booking.com by keeping this reservation in sync.', 'guest-management-system'); ?></p>
+
+                        <div class="gms-platform-sync__summary">
+                            <div class="gms-platform-sync__summary-item">
+                                <span class="gms-platform-sync__label"><?php esc_html_e('Platform', 'guest-management-system'); ?></span>
+                                <span class="gms-platform-sync__value"><?php echo $platform_label !== '' ? esc_html($platform_label) : esc_html__('Not set', 'guest-management-system'); ?></span>
+                            </div>
+                            <div class="gms-platform-sync__summary-item">
+                                <span class="gms-platform-sync__label"><?php esc_html_e('Booking Reference', 'guest-management-system'); ?></span>
+                                <span class="gms-platform-sync__value<?php echo $form_values['booking_reference'] === '' ? ' gms-platform-sync__value--muted' : ''; ?>"><?php echo $form_values['booking_reference'] !== '' ? esc_html($form_values['booking_reference']) : esc_html__('Not provided', 'guest-management-system'); ?></span>
+                            </div>
+                            <div class="gms-platform-sync__summary-item">
+                                <span class="gms-platform-sync__label"><?php esc_html_e('Connection', 'guest-management-system'); ?></span>
+                                <span class="gms-platform-sync__value<?php echo $platform_credentials_ready ? '' : ' gms-platform-sync__value--muted'; ?>"><?php echo $platform_credentials_ready ? esc_html__('Connected', 'guest-management-system') : esc_html__('Credentials missing', 'guest-management-system'); ?></span>
+                            </div>
+                            <div class="gms-platform-sync__summary-item">
+                                <span class="gms-platform-sync__label"><?php esc_html_e('Last Synced', 'guest-management-system'); ?></span>
+                                <?php
+                                $last_synced_display = !empty($platform_meta['last_synced']) ? $this->format_admin_datetime($platform_meta['last_synced']) : '';
+                                ?>
+                                <span class="gms-platform-sync__value<?php echo $last_synced_display === '' ? ' gms-platform-sync__value--muted' : ''; ?>"><?php echo $last_synced_display !== '' ? esc_html($last_synced_display) : esc_html__('Not yet synced', 'guest-management-system'); ?></span>
+                            </div>
+                        </div>
+
+                        <?php if (!empty($platform_meta['snapshot'])) : ?>
+                            <ul class="gms-platform-sync__snapshot-list">
+                                <?php if (!empty($platform_meta['snapshot']['status'])) : ?>
+                                    <li><?php printf(esc_html__('Latest status: %s', 'guest-management-system'), esc_html(ucwords(str_replace('_', ' ', $platform_meta['snapshot']['status'])))); ?></li>
+                                <?php elseif (!empty($platform_meta['snapshot']['status_raw'])) : ?>
+                                    <li><?php printf(esc_html__('Latest status: %s', 'guest-management-system'), esc_html($platform_meta['snapshot']['status_raw'])); ?></li>
+                                <?php endif; ?>
+                                <?php if (!empty($platform_meta['snapshot']['checkin_date'])) : ?>
+                                    <li><?php printf(esc_html__('Check-in synced: %s', 'guest-management-system'), esc_html($this->format_admin_datetime($platform_meta['snapshot']['checkin_date']))); ?></li>
+                                <?php endif; ?>
+                                <?php if (!empty($platform_meta['snapshot']['checkout_date'])) : ?>
+                                    <li><?php printf(esc_html__('Check-out synced: %s', 'guest-management-system'), esc_html($this->format_admin_datetime($platform_meta['snapshot']['checkout_date']))); ?></li>
+                                <?php endif; ?>
+                            </ul>
+                        <?php endif; ?>
+
+                        <?php if (!empty($platform_refresh_feedback['messages'])) : ?>
+                            <div class="gms-step-feedback <?php echo esc_attr($this->map_feedback_class($platform_refresh_feedback['type'])); ?>">
+                                <ul>
+                                    <?php foreach ($platform_refresh_feedback['messages'] as $message) : ?>
+                                        <li><?php echo esc_html($message); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if ($platform_key !== '' && $form_values['booking_reference'] !== '' && $platform_credentials_ready) : ?>
+                            <form method="post" class="gms-platform-sync__form">
+                                <?php wp_nonce_field('gms_refresh_platform_' . $reservation_id); ?>
+                                <input type="hidden" name="gms_action" value="refresh_platform_reservation">
+                                <input type="hidden" name="reservation_id" value="<?php echo esc_attr($reservation_id); ?>">
+                                <button type="submit" class="button button-secondary"><?php printf(esc_html__('Refresh from %s', 'guest-management-system'), esc_html($platform_button_label)); ?></button>
+                                <span class="gms-platform-sync__hint"><?php esc_html_e('Pull the latest guest and stay details from the connected platform.', 'guest-management-system'); ?></span>
+                            </form>
+                        <?php else : ?>
+                            <p class="gms-platform-sync__hint"><?php esc_html_e('Add a platform, booking reference, and credentials to enable one-click sync.', 'guest-management-system'); ?></p>
+                        <?php endif; ?>
+                    </div>
+                    <div class="gms-panel">
+                        <h2><?php esc_html_e('Reservation Details', 'guest-management-system'); ?></h2>
+                        <form method="post" class="gms-reservation-form">
+                            <?php wp_nonce_field('gms_edit_reservation_' . $reservation_id); ?>
+                            <input type="hidden" name="gms_action" value="">
+                            <input type="hidden" name="reservation_id" value="<?php echo esc_attr($reservation_id); ?>">
+                            <div class="gms-reservation-form__grid">
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_guest_name_edit"><?php esc_html_e('Guest Name', 'guest-management-system'); ?></label>
+                                    <input name="guest_name" type="text" id="gms_guest_name_edit" value="<?php echo esc_attr($form_values['guest_name']); ?>" required>
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_guest_email_edit"><?php esc_html_e('Guest Email', 'guest-management-system'); ?></label>
+                                    <input name="guest_email" type="email" id="gms_guest_email_edit" value="<?php echo esc_attr($form_values['guest_email']); ?>">
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_guest_phone_edit"><?php esc_html_e('Guest Phone', 'guest-management-system'); ?></label>
+                                    <input name="guest_phone" type="text" id="gms_guest_phone_edit" value="<?php echo esc_attr($form_values['guest_phone']); ?>">
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_property_name_edit"><?php esc_html_e('Property Name', 'guest-management-system'); ?></label>
+                                    <input name="property_name" type="text" id="gms_property_name_edit" value="<?php echo esc_attr($form_values['property_name']); ?>">
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_property_id_edit"><?php esc_html_e('Property ID', 'guest-management-system'); ?></label>
+                                    <input name="property_id" type="text" id="gms_property_id_edit" value="<?php echo esc_attr($form_values['property_id']); ?>">
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_booking_reference_edit"><?php esc_html_e('Booking Reference', 'guest-management-system'); ?></label>
+                                    <input name="booking_reference" type="text" id="gms_booking_reference_edit" value="<?php echo esc_attr($form_values['booking_reference']); ?>">
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_door_code_edit"><?php esc_html_e('Door Code', 'guest-management-system'); ?></label>
+                                    <input name="door_code" type="text" id="gms_door_code_edit" value="<?php echo esc_attr($form_values['door_code']); ?>" maxlength="4" pattern="\d{4}" inputmode="numeric">
+                                    <p class="description"><?php esc_html_e('Provide the 4-digit entry code for the guest.', 'guest-management-system'); ?></p>
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_checkin_date_edit"><?php esc_html_e('Check-in Date', 'guest-management-system'); ?></label>
+                                    <input name="checkin_date" type="datetime-local" id="gms_checkin_date_edit" value="<?php echo esc_attr($form_values['checkin_date']); ?>">
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_checkout_date_edit"><?php esc_html_e('Check-out Date', 'guest-management-system'); ?></label>
+                                    <input name="checkout_date" type="datetime-local" id="gms_checkout_date_edit" value="<?php echo esc_attr($form_values['checkout_date']); ?>">
+                                </div>
+                                <div class="gms-reservation-form__field">
+                                    <label for="gms_status_edit"><?php esc_html_e('Status', 'guest-management-system'); ?></label>
+                                    <select name="status" id="gms_status_edit">
+                                        <?php foreach ($status_options as $status_key => $status_text) : ?>
+                                            <option value="<?php echo esc_attr($status_key); ?>"<?php selected($form_values['status'], $status_key); ?>><?php echo esc_html($status_text); ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                            </div>
+                            <?php submit_button(__('Update Reservation', 'guest-management-system')); ?>
+                        </form>
+                    </div>
+                </div>
+                <div class="gms-reservation-detail__activity">
+                    <div class="gms-panel gms-activity-panel">
+                        <div class="gms-activity-panel__header">
+                            <h2><?php esc_html_e('Communication Feed', 'guest-management-system'); ?></h2>
+                            <?php if ($activity_total > 0) : ?>
+                                <span class="gms-activity-panel__count"><?php printf(esc_html__('%d logged', 'guest-management-system'), absint($activity_total)); ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <p class="gms-activity-panel__intro"><?php esc_html_e('Most recent messages across email, SMS, OTA, and portal updates.', 'guest-management-system'); ?></p>
+                        <?php if ($latest_activity_display !== '') : ?>
+                            <p class="gms-activity-panel__meta"><?php printf(esc_html__('Last logged: %s', 'guest-management-system'), esc_html($latest_activity_display)); ?></p>
+                        <?php endif; ?>
+                        <?php $this->render_activity_timeline($activity_logs); ?>
+                        <?php if ($activity_total > count($activity_logs)) : ?>
+                            <p class="gms-activity-panel__hint"><?php esc_html_e('Showing the 30 most recent communications. View older activity in the messaging history.', 'guest-management-system'); ?></p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
         </div>
         <?php
+    }
+
+    private function map_reservation_to_form_values($reservation) {
+        return array(
+            'guest_name' => isset($reservation['guest_name']) ? $reservation['guest_name'] : '',
+            'guest_email' => isset($reservation['guest_email']) ? $reservation['guest_email'] : '',
+            'guest_phone' => isset($reservation['guest_phone']) ? $reservation['guest_phone'] : '',
+            'property_name' => isset($reservation['property_name']) ? $reservation['property_name'] : '',
+            'property_id' => isset($reservation['property_id']) ? $reservation['property_id'] : '',
+            'booking_reference' => isset($reservation['booking_reference']) ? $reservation['booking_reference'] : '',
+            'door_code' => isset($reservation['door_code']) ? GMS_Database::sanitizeDoorCode($reservation['door_code']) : '',
+            'checkin_date' => $this->format_datetime_for_input(isset($reservation['checkin_date']) ? $reservation['checkin_date'] : ''),
+            'checkout_date' => $this->format_datetime_for_input(isset($reservation['checkout_date']) ? $reservation['checkout_date'] : ''),
+            'status' => isset($reservation['status']) ? $reservation['status'] : 'pending',
+        );
+    }
+
+    private function filter_communications_by_context($communications, $contexts, $include_types = array()) {
+        $filtered = array();
+
+        if (empty($communications) || !is_array($communications)) {
+            return $filtered;
+        }
+
+        $contexts = array_filter(array_map('sanitize_key', (array) $contexts));
+        $include_types = array_filter(array_map('sanitize_key', (array) $include_types));
+
+        foreach ($communications as $communication) {
+            if (!is_array($communication)) {
+                continue;
+            }
+
+            $context_value = '';
+            if (isset($communication['response_data']) && is_array($communication['response_data']) && isset($communication['response_data']['context'])) {
+                $context_value = sanitize_key($communication['response_data']['context']);
+            }
+
+            $type_value = isset($communication['communication_type']) ? sanitize_key($communication['communication_type']) : '';
+
+            $matches_context = (!empty($contexts) && $context_value !== '' && in_array($context_value, $contexts, true));
+
+            if (!$matches_context && !empty($include_types)) {
+                $matches_context = ($type_value !== '' && in_array($type_value, $include_types, true));
+            }
+
+            if ($matches_context) {
+                $filtered[] = $communication;
+            }
+        }
+
+        usort($filtered, function ($a, $b) {
+            $a_time = isset($a['sent_at']) ? strtotime($a['sent_at']) : 0;
+            $b_time = isset($b['sent_at']) ? strtotime($b['sent_at']) : 0;
+
+            if ($a_time === $b_time) {
+                $a_id = isset($a['id']) ? intval($a['id']) : 0;
+                $b_id = isset($b['id']) ? intval($b['id']) : 0;
+                return $b_id <=> $a_id;
+            }
+
+            return $b_time <=> $a_time;
+        });
+
+        return $filtered;
+    }
+
+    private function determine_step_status($logs, $scheduled_timestamp, $now) {
+        if (!empty($logs)) {
+            return 'complete';
+        }
+
+        if (empty($scheduled_timestamp)) {
+            return 'upcoming';
+        }
+
+        if ($scheduled_timestamp <= $now) {
+            return 'due';
+        }
+
+        return 'upcoming';
+    }
+
+    private function get_step_status_meta($status) {
+        switch ($status) {
+            case 'complete':
+                return array(
+                    'label' => __('Completed', 'guest-management-system'),
+                    'class' => 'is-complete',
+                );
+            case 'due':
+                return array(
+                    'label' => __('Action recommended', 'guest-management-system'),
+                    'class' => 'is-due',
+                );
+            default:
+                return array(
+                    'label' => __('Scheduled', 'guest-management-system'),
+                    'class' => 'is-upcoming',
+                );
+        }
+    }
+
+    private function format_schedule_description($checkin_timestamp, $target_timestamp, $window_label, $now) {
+        if (empty($checkin_timestamp)) {
+            return __('Add a check-in date to calculate this automation.', 'guest-management-system');
+        }
+
+        if (empty($target_timestamp)) {
+            return sprintf(__('Scheduled %s.', 'guest-management-system'), $window_label);
+        }
+
+        $formatted_target = $this->format_timestamp_for_admin($target_timestamp);
+
+        if ($target_timestamp <= $now) {
+            return sprintf(__('Would have sent on %1$s (%2$s). Ready whenever you are.', 'guest-management-system'), $formatted_target, $window_label);
+        }
+
+        return sprintf(__('Scheduled for %1$s (%2$s).', 'guest-management-system'), $formatted_target, $window_label);
+    }
+
+    private function format_admin_datetime($datetime) {
+        if (empty($datetime) || $datetime === '0000-00-00 00:00:00') {
+            return '';
+        }
+
+        $timestamp = strtotime($datetime);
+        if ($timestamp === false) {
+            return '';
+        }
+
+        return $this->format_timestamp_for_admin($timestamp);
+    }
+
+    private function format_timestamp_for_admin($timestamp) {
+        if (empty($timestamp)) {
+            return '';
+        }
+
+        $format = get_option('date_format', 'M j, Y') . ' ' . get_option('time_format', 'g:i a');
+
+        return wp_date($format, $timestamp);
+    }
+
+    private function render_step_timeline($logs) {
+        $this->render_timeline($logs, __('No activity recorded yet for this step.', 'guest-management-system'), 'step');
+    }
+
+    private function render_activity_timeline($logs) {
+        $this->render_timeline($logs, __('No communications logged yet for this reservation.', 'guest-management-system'), 'activity');
+    }
+
+    private function render_timeline($logs, $empty_message, $context = 'step') {
+        $empty_class = $context === 'activity' ? 'gms-reservation-activity__empty' : 'gms-reservation-step__empty';
+
+        if (empty($logs)) {
+            echo '<p class="' . esc_attr($empty_class) . '">' . esc_html($empty_message) . '</p>';
+            return;
+        }
+
+        $classes = array('gms-reservation-timeline');
+        if ($context !== '') {
+            $classes[] = 'gms-reservation-timeline--' . sanitize_html_class($context);
+        }
+
+        echo '<ul class="' . esc_attr(implode(' ', $classes)) . '">';
+        foreach ($logs as $log) {
+            if (!is_array($log)) {
+                continue;
+            }
+
+            $type_label = $this->describe_communication_type($log);
+            $timestamp = $this->format_admin_datetime($log['sent_at'] ?? '');
+
+            $summary_parts = array();
+
+            $recipient = isset($log['recipient']) ? trim((string) $log['recipient']) : '';
+            if ($recipient !== '') {
+                $summary_parts[] = array(
+                    'text' => __('Recipient: %s', 'guest-management-system'),
+                    'value' => $recipient,
+                );
+            }
+
+            $status = isset($log['delivery_status']) ? trim((string) $log['delivery_status']) : '';
+            if ($status !== '') {
+                $status_label = ucwords(str_replace('_', ' ', $status));
+                $summary_parts[] = array(
+                    'text' => __('Status: %s', 'guest-management-system'),
+                    'value' => $status_label,
+                );
+            }
+
+            $subject = isset($log['subject']) ? trim((string) $log['subject']) : '';
+            $message = isset($log['message']) ? trim(wp_strip_all_tags((string) $log['message'])) : '';
+
+            if ($subject !== '') {
+                $summary_parts[] = array(
+                    'text' => __('Subject: %s', 'guest-management-system'),
+                    'value' => $subject,
+                );
+            } elseif ($message !== '') {
+                $summary_parts[] = array(
+                    'text' => __('Message: %s', 'guest-management-system'),
+                    'value' => wp_trim_words($message, 16, '…'),
+                );
+            }
+
+            $response_data = isset($log['response_data']) && is_array($log['response_data']) ? $log['response_data'] : array();
+            if (isset($response_data['door_code'])) {
+                $door_code = GMS_Database::sanitizeDoorCode($response_data['door_code']);
+                if ($door_code !== '') {
+                    $summary_parts[] = array(
+                        'text' => __('Door code %s', 'guest-management-system'),
+                        'value' => $door_code,
+                    );
+                }
+            }
+
+            if (isset($response_data['platform'])) {
+                $platform_key = sanitize_key($response_data['platform']);
+                $platform_label = '';
+
+                if ($platform_key !== '' && function_exists('gms_get_platform_display')) {
+                    $platform_lookup = str_replace('_', '.', $platform_key);
+                    $platform_info = gms_get_platform_display($platform_lookup);
+                    if (is_array($platform_info) && isset($platform_info['name'])) {
+                        $platform_label = $platform_info['name'];
+                    }
+                }
+
+                if ($platform_label === '' && $platform_key !== '') {
+                    $platform_label = ucwords(str_replace('_', ' ', $platform_key));
+                }
+
+                if ($platform_label !== '') {
+                    $summary_parts[] = array(
+                        'text' => __('Platform: %s', 'guest-management-system'),
+                        'value' => $platform_label,
+                    );
+                }
+            }
+
+            if (isset($response_data['thread_id'])) {
+                $thread_id = trim((string) $response_data['thread_id']);
+                if ($thread_id !== '') {
+                    $summary_parts[] = array(
+                        'text' => __('Thread: %s', 'guest-management-system'),
+                        'value' => $thread_id,
+                    );
+                }
+            }
+
+            $provider_reference = isset($log['provider_reference']) ? trim((string) $log['provider_reference']) : '';
+            if ($provider_reference !== '') {
+                $summary_parts[] = array(
+                    'text' => __('Reference: %s', 'guest-management-system'),
+                    'value' => $provider_reference,
+                );
+            }
+
+            echo '<li class="gms-reservation-timeline__item">';
+            echo '<div class="gms-reservation-timeline__type">' . esc_html($type_label) . '</div>';
+            if ($timestamp !== '') {
+                echo '<div class="gms-reservation-timeline__timestamp">' . esc_html($timestamp) . '</div>';
+            }
+
+            if (!empty($summary_parts)) {
+                $formatted_parts = array();
+
+                foreach ($summary_parts as $part) {
+                    if (!is_array($part) || !isset($part['text'])) {
+                        continue;
+                    }
+
+                    $value = isset($part['value']) ? $part['value'] : '';
+                    $formatted_parts[] = sprintf($part['text'], esc_html($value));
+                }
+
+                if (!empty($formatted_parts)) {
+                    echo '<div class="gms-reservation-timeline__summary">' . implode(' <span class="gms-reservation-timeline__separator">&middot;</span> ', $formatted_parts) . '</div>';
+                }
+            }
+
+            echo '</li>';
+        }
+        echo '</ul>';
+    }
+
+    private function describe_communication_type($entry) {
+        $type = isset($entry['communication_type']) ? sanitize_key($entry['communication_type']) : '';
+        $channel = isset($entry['channel']) ? sanitize_key($entry['channel']) : '';
+
+        if ($type === 'sms' || $channel === 'sms') {
+            return __('SMS', 'guest-management-system');
+        }
+
+        if ($type === 'portal_update' || $channel === 'portal') {
+            return __('Portal Update', 'guest-management-system');
+        }
+
+        if ($type === 'whatsapp' || $channel === 'whatsapp') {
+            return __('WhatsApp', 'guest-management-system');
+        }
+
+        $platform_channels = array(
+            'airbnb' => __('Airbnb Message', 'guest-management-system'),
+            'vrbo' => __('VRBO Message', 'guest-management-system'),
+            'booking_com' => __('Booking.com Message', 'guest-management-system'),
+            'bookingcom' => __('Booking.com Message', 'guest-management-system'),
+        );
+
+        if (isset($platform_channels[$channel])) {
+            return $platform_channels[$channel];
+        }
+
+        if ($type === 'platform_message') {
+            return __('OTA Message', 'guest-management-system');
+        }
+
+        return __('Email', 'guest-management-system');
+    }
+
+    private function map_feedback_class($type) {
+        switch ($type) {
+            case 'success':
+                return 'is-success';
+            case 'warning':
+                return 'is-warning';
+            case 'error':
+                return 'is-error';
+            default:
+                return '';
+        }
+    }
+
+    private function resolve_feedback_type($successes, $attempts) {
+        if ($successes <= 0) {
+            return 'error';
+        }
+
+        if ($successes >= $attempts) {
+            return 'success';
+        }
+
+        return 'warning';
+    }
+
+    private function trigger_portal_link_delivery($reservation_id) {
+        $reservation = GMS_Database::getReservationById($reservation_id);
+
+        if (!$reservation) {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Unable to load reservation details. Please try again.', 'guest-management-system')),
+            );
+        }
+
+        $messages = array();
+        $successes = 0;
+        $attempts = 0;
+
+        $guest_email = isset($reservation['guest_email']) ? sanitize_email($reservation['guest_email']) : '';
+        if ($guest_email !== '' && is_email($guest_email)) {
+            $attempts++;
+            $email_handler = new GMS_Email_Handler();
+            $email_sent = $email_handler->sendReservationApprovedEmail($reservation);
+            if ($email_sent) {
+                $successes++;
+                $messages[] = __('Portal invitation email sent successfully.', 'guest-management-system');
+            } else {
+                $messages[] = __('Portal invitation email failed to send.', 'guest-management-system');
+            }
+        } else {
+            $messages[] = __('Portal email skipped—add a valid guest email to send automatically.', 'guest-management-system');
+        }
+
+        $guest_phone = isset($reservation['guest_phone']) ? $reservation['guest_phone'] : '';
+        if ($guest_phone !== '') {
+            $attempts++;
+            $sms_handler = new GMS_SMS_Handler();
+            $sms_sent = $sms_handler->sendReservationApprovedSMS($reservation);
+            if ($sms_sent) {
+                $successes++;
+                $messages[] = __('Portal SMS sent successfully.', 'guest-management-system');
+            } else {
+                $messages[] = __('Portal SMS failed to send.', 'guest-management-system');
+            }
+        } else {
+            $messages[] = __('Portal SMS skipped—add a guest phone number to enable SMS delivery.', 'guest-management-system');
+        }
+
+        if (class_exists('GMS_OTA_Messaging_Handler')) {
+            $ota_handler = new GMS_OTA_Messaging_Handler();
+            $ota_result = $ota_handler->sendPortalInvitation($reservation);
+
+            if (!empty($ota_result['message'])) {
+                $messages[] = $ota_result['message'];
+            }
+
+            if (isset($ota_result['status']) && $ota_result['status'] !== 'skipped') {
+                $attempts++;
+                if (!empty($ota_result['success'])) {
+                    $successes++;
+                }
+            }
+        }
+
+        $type = $this->resolve_feedback_type($successes, max($attempts, 1));
+
+        return array(
+            'type' => $type,
+            'messages' => $messages,
+        );
+    }
+
+    private function trigger_door_code_delivery($reservation_id) {
+        $reservation = GMS_Database::getReservationById($reservation_id);
+
+        if (!$reservation) {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Unable to load reservation details. Please try again.', 'guest-management-system')),
+            );
+        }
+
+        $door_code = GMS_Database::sanitizeDoorCode($reservation['door_code'] ?? '');
+        if ($door_code === '') {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Add a 4-digit door code before sending the access package.', 'guest-management-system')),
+            );
+        }
+
+        $messages = array();
+        $successes = 0;
+        $attempts = 0;
+
+        $guest_email = isset($reservation['guest_email']) ? sanitize_email($reservation['guest_email']) : '';
+        if ($guest_email !== '' && is_email($guest_email)) {
+            $attempts++;
+            $email_handler = new GMS_Email_Handler();
+            $email_sent = $email_handler->sendDoorCodeEmail($reservation, $door_code);
+            if ($email_sent) {
+                $successes++;
+                $messages[] = __('Door code email sent successfully.', 'guest-management-system');
+            } else {
+                $messages[] = __('Door code email failed to send.', 'guest-management-system');
+            }
+        } else {
+            $messages[] = __('Door code email skipped—add a valid guest email to enable delivery.', 'guest-management-system');
+        }
+
+        $guest_phone = isset($reservation['guest_phone']) ? $reservation['guest_phone'] : '';
+        if ($guest_phone !== '') {
+            $attempts++;
+            $sms_handler = new GMS_SMS_Handler();
+            $sms_sent = $sms_handler->sendDoorCodeSMS($reservation, $door_code);
+            if ($sms_sent) {
+                $successes++;
+                $messages[] = __('Door code SMS sent successfully.', 'guest-management-system');
+            } else {
+                $messages[] = __('Door code SMS failed to send.', 'guest-management-system');
+            }
+        } else {
+            $messages[] = __('Door code SMS skipped—add a guest phone number to enable SMS delivery.', 'guest-management-system');
+        }
+
+        if (class_exists('GMS_OTA_Messaging_Handler')) {
+            $ota_handler = new GMS_OTA_Messaging_Handler();
+            $ota_result = $ota_handler->sendDoorCodeMessage($reservation, $door_code);
+
+            if (!empty($ota_result['message'])) {
+                $messages[] = $ota_result['message'];
+            }
+
+            if (isset($ota_result['status']) && $ota_result['status'] !== 'skipped') {
+                $attempts++;
+                if (!empty($ota_result['success'])) {
+                    $successes++;
+                }
+            }
+        }
+
+        $attempts++;
+        $portal_logged = $this->log_portal_door_code_update($reservation_id, intval($reservation['guest_id'] ?? 0), $door_code);
+        if ($portal_logged) {
+            $successes++;
+            $messages[] = __('Guest portal updated with the latest door code.', 'guest-management-system');
+        } else {
+            $messages[] = __('Unable to record a portal update. Check the activity log.', 'guest-management-system');
+        }
+
+        $type = $this->resolve_feedback_type($successes, $attempts);
+
+        return array(
+            'type' => $type,
+            'messages' => $messages,
+        );
+    }
+
+    private function trigger_welcome_delivery($reservation_id) {
+        $reservation = GMS_Database::getReservationById($reservation_id);
+
+        if (!$reservation) {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Unable to load reservation details. Please try again.', 'guest-management-system')),
+            );
+        }
+
+        $messages = array();
+        $successes = 0;
+        $attempts = 0;
+
+        $guest_email = isset($reservation['guest_email']) ? sanitize_email($reservation['guest_email']) : '';
+        if ($guest_email !== '' && is_email($guest_email)) {
+            $attempts++;
+            $email_handler = new GMS_Email_Handler();
+            $email_sent = $email_handler->sendWelcomeEmail($reservation);
+            if ($email_sent) {
+                $successes++;
+                $messages[] = __('Welcome email sent successfully.', 'guest-management-system');
+            } else {
+                $messages[] = __('Welcome email failed to send.', 'guest-management-system');
+            }
+        } else {
+            $messages[] = __('Welcome email skipped—add a valid guest email to enable delivery.', 'guest-management-system');
+        }
+
+        $guest_phone = isset($reservation['guest_phone']) ? $reservation['guest_phone'] : '';
+        if ($guest_phone !== '') {
+            $attempts++;
+            $sms_handler = new GMS_SMS_Handler();
+            $sms_sent = $sms_handler->sendWelcomeSMS($reservation);
+            if ($sms_sent) {
+                $successes++;
+                $messages[] = __('Welcome SMS sent successfully.', 'guest-management-system');
+            } else {
+                $messages[] = __('Welcome SMS failed to send.', 'guest-management-system');
+            }
+        } else {
+            $messages[] = __('Welcome SMS skipped—add a guest phone number to enable SMS delivery.', 'guest-management-system');
+        }
+
+        if (class_exists('GMS_OTA_Messaging_Handler')) {
+            $ota_handler = new GMS_OTA_Messaging_Handler();
+            $ota_result = $ota_handler->sendWelcomeMessage($reservation);
+
+            if (!empty($ota_result['message'])) {
+                $messages[] = $ota_result['message'];
+            }
+
+            if (isset($ota_result['status']) && $ota_result['status'] !== 'skipped') {
+                $attempts++;
+                if (!empty($ota_result['success'])) {
+                    $successes++;
+                }
+            }
+        }
+
+        $type = $this->resolve_feedback_type($successes, max($attempts, 1));
+
+        return array(
+            'type' => $type,
+            'messages' => $messages,
+        );
+    }
+
+    private function log_portal_door_code_update($reservation_id, $guest_id, $door_code) {
+        $sanitized_code = GMS_Database::sanitizeDoorCode($door_code);
+
+        if ($sanitized_code === '') {
+            return 0;
+        }
+
+        return GMS_Database::logCommunication(array(
+            'reservation_id' => intval($reservation_id),
+            'guest_id' => intval($guest_id),
+            'type' => 'portal_update',
+            'channel' => 'portal',
+            'message' => sprintf(__('Door code %s synced to the guest portal.', 'guest-management-system'), $sanitized_code),
+            'status' => 'completed',
+            'response_data' => array(
+                'context' => 'door_code_sequence',
+                'door_code' => $sanitized_code,
+            ),
+            'sent_at' => current_time('mysql'),
+        ));
+    }
+
+    private function handle_platform_sync_request() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        check_admin_referer('gms_sync_platform_reservations');
+
+        $platform = isset($_POST['gms_sync_platform']) ? sanitize_key(wp_unslash($_POST['gms_sync_platform'])) : 'all';
+        $since_raw = isset($_POST['gms_sync_since']) ? wp_unslash($_POST['gms_sync_since']) : '';
+        $limit = isset($_POST['gms_sync_limit']) ? absint(wp_unslash($_POST['gms_sync_limit'])) : 0;
+
+        $args = array();
+
+        if ($since_raw !== '' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $since_raw)) {
+            $args['since'] = $since_raw;
+        }
+
+        if ($limit > 0) {
+            $args['limit'] = $limit;
+        }
+
+        if (!class_exists('GMS_OTA_Reservation_Sync')) {
+            $result = array(
+                'success' => false,
+                'created' => 0,
+                'updated' => 0,
+                'synced' => 0,
+                'skipped' => 0,
+                'errors' => array(__('OTA reservation sync handler is not available.', 'guest-management-system')),
+                'messages' => array(),
+            );
+        } else {
+            $handler = new GMS_OTA_Reservation_Sync();
+            if ($platform === '' || $platform === 'all') {
+                $result = $handler->import_all_platforms($args);
+                $platform = 'all';
+            } else {
+                $result = $handler->import_platform_reservations($platform, $args);
+            }
+        }
+
+        set_transient($this->get_user_notice_key('platform_sync'), array(
+            'platform' => $platform,
+            'result' => $result,
+        ), MINUTE_IN_SECONDS * 10);
+
+        $redirect_url = add_query_arg(array('page' => 'guest-management-reservations'), admin_url('admin.php'));
+        wp_safe_redirect($redirect_url);
+        exit;
+    }
+
+    private function consume_platform_sync_notice() {
+        $notice_key = $this->get_user_notice_key('platform_sync');
+        $notice = get_transient($notice_key);
+
+        if ($notice !== false) {
+            delete_transient($notice_key);
+        }
+
+        return $notice;
+    }
+
+    private function render_platform_sync_notice($notice) {
+        if (!is_array($notice)) {
+            return;
+        }
+
+        $result = isset($notice['result']) && is_array($notice['result']) ? $notice['result'] : array();
+        $platform = $this->normalize_platform_key($notice['platform'] ?? '');
+
+        $label = $platform === 'all' || $platform === ''
+            ? __('All Platforms', 'guest-management-system')
+            : $this->describe_platform_label($platform);
+
+        if ($label === '') {
+            $label = __('Selected Platform', 'guest-management-system');
+        }
+
+        $created = intval($result['created'] ?? 0);
+        $updated = intval($result['updated'] ?? 0);
+        $synced = intval($result['synced'] ?? 0);
+        $skipped = intval($result['skipped'] ?? 0);
+        $errors = isset($result['errors']) ? array_filter(array_map('trim', (array) $result['errors'])) : array();
+        $messages = isset($result['messages']) ? array_filter(array_map('trim', (array) $result['messages'])) : array();
+
+        $success = !empty($result['success']);
+        $notice_class = $success ? 'notice-success' : 'notice-warning';
+
+        echo '<div class="notice ' . esc_attr($notice_class) . ' is-dismissible">';
+        echo '<p>';
+
+        if ($success) {
+            printf(
+                esc_html__('Synced reservations from %1$s. %2$d created, %3$d updated, %4$d already current.', 'guest-management-system'),
+                esc_html($label),
+                $created,
+                $updated,
+                $synced
+            );
+
+            if ($skipped > 0) {
+                echo ' ';
+                printf(
+                    esc_html(_n('%d record skipped.', '%d records skipped.', $skipped, 'guest-management-system')),
+                    $skipped
+                );
+            }
+        } else {
+            if (!empty($errors)) {
+                esc_html_e('Unable to complete the platform sync.', 'guest-management-system');
+            } else {
+                printf(
+                    esc_html__('No reservations were returned from %s.', 'guest-management-system'),
+                    esc_html($label)
+                );
+            }
+        }
+
+        echo '</p>';
+
+        if (!empty($messages)) {
+            echo '<ul class="gms-platform-sync__notice-list">';
+            foreach ($messages as $message) {
+                echo '<li>' . esc_html($message) . '</li>';
+            }
+            echo '</ul>';
+        }
+
+        if (!empty($errors)) {
+            echo '<ul class="gms-platform-sync__notice-errors">';
+            foreach ($errors as $error) {
+                echo '<li>' . esc_html($error) . '</li>';
+            }
+            echo '</ul>';
+        }
+
+        echo '</div>';
+    }
+
+    private function get_user_notice_key($suffix) {
+        $suffix = sanitize_key($suffix);
+        $user_id = get_current_user_id();
+
+        if (!$user_id) {
+            $user_id = 0;
+        }
+
+        return sprintf('gms_%s_notice_%d', $suffix, $user_id);
+    }
+
+    private function normalize_platform_key($platform) {
+        $platform = strtolower(trim((string) $platform));
+
+        if ($platform === '') {
+            return '';
+        }
+
+        $platform = str_replace(array('.', ' ', '-'), '_', $platform);
+
+        if ($platform === 'bookingcom') {
+            $platform = 'booking_com';
+        }
+
+        return $platform;
+    }
+
+    private function describe_platform_label($platform_key) {
+        $platform_key = $this->normalize_platform_key($platform_key);
+
+        if ($platform_key === '') {
+            return '';
+        }
+
+        if (class_exists('GMS_OTA_Reservation_Sync')) {
+            $sync = new GMS_OTA_Reservation_Sync();
+            $config = $sync->get_platform_config();
+        } else {
+            $config = apply_filters('gms_ota_reservation_config', array());
+        }
+
+        if (isset($config[$platform_key]['label'])) {
+            return wp_strip_all_tags((string) $config[$platform_key]['label']);
+        }
+
+        return ucwords(str_replace('_', ' ', $platform_key));
+    }
+
+    private function platform_credentials_ready($platform_key) {
+        $platform_key = $this->normalize_platform_key($platform_key);
+
+        if ($platform_key === '') {
+            return false;
+        }
+
+        if (class_exists('GMS_OTA_Reservation_Sync')) {
+            $sync = new GMS_OTA_Reservation_Sync();
+            $config = $sync->get_platform_config();
+        } else {
+            $config = apply_filters('gms_ota_reservation_config', array());
+        }
+
+        if (!isset($config[$platform_key]['option'])) {
+            return false;
+        }
+
+        $token = trim((string) get_option($config[$platform_key]['option'], ''));
+
+        return $token !== '';
+    }
+
+    private function extract_platform_sync_snapshot($reservation, $platform_key) {
+        $platform_key = $this->normalize_platform_key($platform_key);
+        $webhook = isset($reservation['webhook_data']) && is_array($reservation['webhook_data']) ? $reservation['webhook_data'] : array();
+        $sync_data = array();
+
+        if (isset($webhook['ota_sync']) && is_array($webhook['ota_sync']) && isset($webhook['ota_sync'][$platform_key]) && is_array($webhook['ota_sync'][$platform_key])) {
+            $sync_data = $webhook['ota_sync'][$platform_key];
+        }
+
+        $snapshot = isset($sync_data['snapshot']) && is_array($sync_data['snapshot']) ? $sync_data['snapshot'] : array();
+        $synced_fields = isset($sync_data['synced_fields']) ? array_filter(array_map('sanitize_key', (array) $sync_data['synced_fields'])) : array();
+        $last_synced = isset($sync_data['last_synced']) ? trim((string) $sync_data['last_synced']) : '';
+
+        return array(
+            'snapshot' => $snapshot,
+            'synced_fields' => $synced_fields,
+            'last_synced' => $last_synced,
+        );
+    }
+
+    private function refresh_reservation_from_platform($reservation) {
+        if (!is_array($reservation) || empty($reservation)) {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Unable to load reservation details. Please try again.', 'guest-management-system')),
+            );
+        }
+
+        $platform_key = $this->normalize_platform_key($reservation['platform'] ?? '');
+        if ($platform_key === '') {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Set the reservation platform before refreshing.', 'guest-management-system')),
+            );
+        }
+
+        $booking_reference = sanitize_text_field($reservation['booking_reference'] ?? '');
+        if ($booking_reference === '') {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Add the platform booking reference before refreshing.', 'guest-management-system')),
+            );
+        }
+
+        if (!$this->platform_credentials_ready($platform_key)) {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('Add the platform credentials in settings to sync reservation details.', 'guest-management-system')),
+            );
+        }
+
+        if (!class_exists('GMS_OTA_Reservation_Sync')) {
+            return array(
+                'type' => 'error',
+                'messages' => array(__('OTA reservation sync handler is not available.', 'guest-management-system')),
+            );
+        }
+
+        $handler = new GMS_OTA_Reservation_Sync();
+        $result = $handler->sync_reservation($reservation);
+
+        $messages = array();
+
+        if (!empty($result['message'])) {
+            $messages[] = $result['message'];
+        }
+
+        if (!empty($result['errors'])) {
+            $messages = array_merge($messages, array_filter(array_map('trim', (array) $result['errors'])));
+        }
+
+        if (empty($messages)) {
+            if (!empty($result['success'])) {
+                $messages[] = __('Reservation is already up to date with the platform.', 'guest-management-system');
+            } else {
+                $messages[] = __('Platform sync failed. Review the connection settings and try again.', 'guest-management-system');
+            }
+        }
+
+        $type = !empty($result['success']) ? 'success' : 'error';
+
+        return array(
+            'type' => $type,
+            'messages' => $messages,
+        );
     }
 
     protected function render_missing_reservation_notice() {

--- a/includes/class-database.php
+++ b/includes/class-database.php
@@ -1262,6 +1262,30 @@ class GMS_Database {
         return self::formatReservationRow($row);
     }
 
+    public static function getReservationByPlatformReference($platform, $booking_reference) {
+        global $wpdb;
+
+        $platform = sanitize_text_field($platform);
+        $booking_reference = sanitize_text_field($booking_reference);
+
+        if ($platform === '' || $booking_reference === '') {
+            return null;
+        }
+
+        $table_name = $wpdb->prefix . 'gms_reservations';
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT * FROM $table_name WHERE platform = %s AND booking_reference = %s LIMIT 1",
+                $platform,
+                $booking_reference
+            ),
+            ARRAY_A
+        );
+
+        return $row ? self::formatReservationRow($row) : null;
+    }
+
     public static function updateReservation($reservation_id, $data) {
         global $wpdb;
         $table_name = $wpdb->prefix . 'gms_reservations';

--- a/includes/class-ota-messaging-handler.php
+++ b/includes/class-ota-messaging-handler.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * OTA messaging handler for posting updates to Airbnb, VRBO, and Booking.com inboxes.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class GMS_OTA_Messaging_Handler {
+
+    /**
+     * Map supported platforms to option keys and default endpoints.
+     *
+     * @return array
+     */
+    private function get_platform_config() {
+        $defaults = array(
+            'airbnb' => array(
+                'label' => __('Airbnb', 'guest-management-system'),
+                'option' => 'gms_airbnb_access_token',
+                'endpoint' => 'https://api.airbnb.com/v2/messages',
+            ),
+            'vrbo' => array(
+                'label' => __('VRBO', 'guest-management-system'),
+                'option' => 'gms_vrbo_access_token',
+                'endpoint' => 'https://partner.api.expediapartnercentral.com/v1/vrbo/messages',
+            ),
+            'booking_com' => array(
+                'label' => __('Booking.com', 'guest-management-system'),
+                'option' => 'gms_booking_access_token',
+                'endpoint' => 'https://distribution-xml.booking.com/json/bookings',
+            ),
+        );
+
+        /**
+         * Filter the OTA platform configuration.
+         *
+         * @param array $defaults Platform configuration array.
+         */
+        return apply_filters('gms_ota_platform_config', $defaults);
+    }
+
+    /**
+     * Send the portal invitation message through the OTA inbox when possible.
+     *
+     * @param array $reservation Reservation data.
+     *
+     * @return array Result data including success boolean, status keyword, and message string.
+     */
+    public function sendPortalInvitation($reservation) {
+        $portal_url = '';
+        $token = isset($reservation['portal_token']) ? sanitize_text_field($reservation['portal_token']) : '';
+        $built_url = gms_build_portal_url($token);
+        if ($built_url !== false) {
+            $portal_url = $built_url;
+        }
+
+        $message = sprintf(
+            /* translators: 1: guest name, 2: property name, 3: portal url */
+            __('Hello %1$s, your guest portal for %2$s is ready: %3$s', 'guest-management-system'),
+            sanitize_text_field($reservation['guest_name'] ?? ''),
+            sanitize_text_field($reservation['property_name'] ?? ''),
+            esc_url_raw($portal_url)
+        );
+
+        return $this->dispatch_platform_message($reservation, array(
+            'context' => 'portal_link_sequence',
+            'subject' => __('Guest Portal Ready', 'guest-management-system'),
+            'body' => $message,
+        ));
+    }
+
+    /**
+     * Send the door code details through the OTA inbox.
+     *
+     * @param array  $reservation Reservation data.
+     * @param string $door_code   Door code string.
+     *
+     * @return array
+     */
+    public function sendDoorCodeMessage($reservation, $door_code) {
+        $sanitized_code = GMS_Database::sanitizeDoorCode($door_code);
+        if ($sanitized_code === '') {
+            return array(
+                'success' => false,
+                'status' => 'skipped',
+                'message' => __('Door code not provided. OTA message skipped.', 'guest-management-system'),
+            );
+        }
+
+        $checkin_raw = isset($reservation['checkin_date']) ? $reservation['checkin_date'] : '';
+        $checkin_time = $checkin_raw ? date_i18n(get_option('time_format', 'g:i a'), strtotime($checkin_raw)) : '';
+        $checkin_date = $checkin_raw ? date_i18n(get_option('date_format', 'M j, Y'), strtotime($checkin_raw)) : '';
+
+        $message = sprintf(
+            /* translators: 1: guest name, 2: property name, 3: door code, 4: check-in date, 5: check-in time */
+            __('Hi %1$s, your access code for %2$s is %3$s. It becomes active on %4$s at %5$s.', 'guest-management-system'),
+            sanitize_text_field($reservation['guest_name'] ?? ''),
+            sanitize_text_field($reservation['property_name'] ?? ''),
+            $sanitized_code,
+            esc_html($checkin_date),
+            esc_html($checkin_time)
+        );
+
+        return $this->dispatch_platform_message($reservation, array(
+            'context' => 'door_code_sequence',
+            'subject' => __('Door Code Details', 'guest-management-system'),
+            'body' => $message,
+            'extra' => array(
+                'door_code' => $sanitized_code,
+            ),
+        ));
+    }
+
+    /**
+     * Send the welcome message through the OTA inbox.
+     *
+     * @param array $reservation Reservation data.
+     *
+     * @return array
+     */
+    public function sendWelcomeMessage($reservation) {
+        $checkin_raw = isset($reservation['checkin_date']) ? $reservation['checkin_date'] : '';
+        $checkin_time = $checkin_raw ? date_i18n(get_option('time_format', 'g:i a'), strtotime($checkin_raw)) : '';
+
+        $message = sprintf(
+            /* translators: 1: guest name, 2: property name, 3: check-in time */
+            __('Welcome %1$s! We look forward to hosting you at %2$s. Check-in is at %3$s—message us here if you need anything.', 'guest-management-system'),
+            sanitize_text_field($reservation['guest_name'] ?? ''),
+            sanitize_text_field($reservation['property_name'] ?? ''),
+            esc_html($checkin_time)
+        );
+
+        return $this->dispatch_platform_message($reservation, array(
+            'context' => 'welcome_sequence',
+            'subject' => __('Welcome to Your Stay', 'guest-management-system'),
+            'body' => $message,
+        ));
+    }
+
+    /**
+     * Normalize a reservation platform value.
+     *
+     * @param string $platform Platform string stored on reservation.
+     *
+     * @return string Normalized key.
+     */
+    private function normalize_platform($platform) {
+        $platform = strtolower(trim((string) $platform));
+        if ($platform === '') {
+            return '';
+        }
+
+        $platform = str_replace(array('.', ' ', '-'), '_', $platform);
+
+        if ($platform === 'bookingcom') {
+            $platform = 'booking_com';
+        }
+
+        return $platform;
+    }
+
+    /**
+     * Resolve the platform configuration for a reservation.
+     *
+     * @param array $reservation Reservation data.
+     *
+     * @return array Array containing key, label, option, and endpoint. Empty array when unsupported.
+     */
+    private function resolve_platform($reservation) {
+        $platform_key = isset($reservation['platform']) ? $this->normalize_platform($reservation['platform']) : '';
+
+        if ($platform_key === '') {
+            return array();
+        }
+
+        $config = $this->get_platform_config();
+
+        if (!isset($config[$platform_key])) {
+            return array();
+        }
+
+        $config[$platform_key]['key'] = $platform_key;
+
+        return $config[$platform_key];
+    }
+
+    /**
+     * Send a message to the OTA platform inbox.
+     *
+     * @param array $reservation Reservation data.
+     * @param array $payload     Message payload details.
+     *
+     * @return array Result array.
+     */
+    private function dispatch_platform_message($reservation, $payload) {
+        if (!is_array($reservation) || empty($reservation)) {
+            return array(
+                'success' => false,
+                'status' => 'skipped',
+                'message' => __('Reservation data missing. OTA message skipped.', 'guest-management-system'),
+            );
+        }
+
+        $platform = $this->resolve_platform($reservation);
+        if (empty($platform)) {
+            return array(
+                'success' => false,
+                'status' => 'skipped',
+                'message' => __('No connected OTA platform for this reservation.', 'guest-management-system'),
+            );
+        }
+
+        $access_token = isset($platform['option']) ? trim((string) get_option($platform['option'], '')) : '';
+        if ($access_token === '') {
+            return array(
+                'success' => false,
+                'status' => 'skipped',
+                'message' => sprintf(
+                    /* translators: %s: platform label */
+                    __('%s messaging credentials are not configured. OTA message skipped.', 'guest-management-system'),
+                    esc_html($platform['label'])
+                ),
+            );
+        }
+
+        $endpoint_map = $this->get_platform_config();
+        $endpoint = isset($platform['endpoint']) ? $platform['endpoint'] : '';
+
+        if ($endpoint === '' && isset($endpoint_map[$platform['key']]['endpoint'])) {
+            $endpoint = $endpoint_map[$platform['key']]['endpoint'];
+        }
+
+        /**
+         * Filter the endpoint URL used for OTA messaging per platform.
+         *
+         * @param string $endpoint    Endpoint URL.
+         * @param string $platformKey Normalized platform key.
+         * @param array  $reservation Reservation payload.
+         */
+        $endpoint = apply_filters('gms_ota_platform_endpoint', $endpoint, $platform['key'], $reservation);
+
+        if (empty($endpoint)) {
+            return array(
+                'success' => false,
+                'status' => 'skipped',
+                'message' => sprintf(
+                    /* translators: %s: platform label */
+                    __('No endpoint configured for %s messaging.', 'guest-management-system'),
+                    esc_html($platform['label'])
+                ),
+            );
+        }
+
+        $body_text = isset($payload['body']) ? wp_strip_all_tags($payload['body']) : '';
+        $subject = isset($payload['subject']) ? wp_strip_all_tags($payload['subject']) : '';
+        $context = isset($payload['context']) ? sanitize_key($payload['context']) : 'ota_message';
+        $reservation_id = intval($reservation['id'] ?? 0);
+        $guest_id = intval($reservation['guest_id'] ?? 0);
+        $booking_reference = sanitize_text_field($reservation['booking_reference'] ?? '');
+
+        $request_payload = array(
+            'reservation_id' => $reservation_id,
+            'booking_reference' => $booking_reference,
+            'subject' => $subject,
+            'message' => $body_text,
+        );
+
+        $request_payload = array_merge($request_payload, isset($payload['extra']) && is_array($payload['extra']) ? $payload['extra'] : array());
+
+        $request_args = array(
+            'headers' => array(
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer ' . $access_token,
+            ),
+            'body' => wp_json_encode($request_payload),
+            'timeout' => 20,
+        );
+
+        $response = wp_remote_post($endpoint, $request_args);
+        $response_code = 0;
+        $response_body = '';
+        $provider_reference = '';
+        $thread_id = '';
+
+        if (!is_wp_error($response)) {
+            $response_code = wp_remote_retrieve_response_code($response);
+            $response_body = wp_remote_retrieve_body($response);
+
+            $decoded = json_decode($response_body, true);
+            if (is_array($decoded)) {
+                if (isset($decoded['message_id'])) {
+                    $provider_reference = sanitize_text_field($decoded['message_id']);
+                }
+                if (isset($decoded['thread_id'])) {
+                    $thread_id = sanitize_text_field($decoded['thread_id']);
+                }
+            }
+        }
+
+        $success = !is_wp_error($response) && $response_code >= 200 && $response_code < 300;
+        $status = $success ? 'sent' : 'failed';
+
+        $log_data = array(
+            'reservation_id' => $reservation_id,
+            'guest_id' => $guest_id,
+            'type' => 'platform_message',
+            'channel' => $platform['key'],
+            'recipient' => sprintf('%s:%s', $platform['key'], $booking_reference !== '' ? $booking_reference : $reservation_id),
+            'subject' => $subject,
+            'message' => $body_text,
+            'status' => $status,
+            'provider_reference' => $provider_reference,
+            'response_data' => array(
+                'context' => $context,
+                'platform' => $platform['key'],
+                'status_code' => $response_code,
+                'thread_id' => $thread_id,
+                'raw_response' => $response_body,
+            ),
+            'sent_at' => current_time('mysql'),
+        );
+
+        if (!$success && is_wp_error($response)) {
+            $log_data['response_data']['error'] = $response->get_error_message();
+        }
+
+        if (isset($payload['extra']['door_code'])) {
+            $log_data['response_data']['door_code'] = $payload['extra']['door_code'];
+        }
+
+        GMS_Database::logCommunication($log_data);
+
+        $message = $success
+            ? sprintf(
+                /* translators: %s: platform label */
+                __('Message delivered through %s inbox.', 'guest-management-system'),
+                esc_html($platform['label'])
+            )
+            : sprintf(
+                /* translators: 1: platform label, 2: status code */
+                __('Failed to deliver via %1$s inbox (HTTP %2$s).', 'guest-management-system'),
+                esc_html($platform['label']),
+                esc_html($response_code ?: 'n/a')
+            );
+
+        return array(
+            'success' => $success,
+            'status' => $status,
+            'message' => $message,
+        );
+    }
+}

--- a/includes/class-ota-reservation-sync.php
+++ b/includes/class-ota-reservation-sync.php
@@ -1,0 +1,1240 @@
+<?php
+/**
+ * OTA reservation synchronization handler.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class GMS_OTA_Reservation_Sync {
+
+    /**
+     * Retrieve OTA platform configuration for reservation syncing.
+     *
+     * @return array
+     */
+    public function get_platform_config() {
+        $defaults = array(
+            'airbnb' => array(
+                'label' => __('Airbnb', 'guest-management-system'),
+                'option' => 'gms_airbnb_access_token',
+                'reservation_endpoint' => 'https://api.airbnb.com/v2/reservations/%s',
+                'collection_endpoint' => 'https://api.airbnb.com/v2/reservations',
+                'reservation_param' => 'confirmation_code',
+            ),
+            'vrbo' => array(
+                'label' => __('VRBO', 'guest-management-system'),
+                'option' => 'gms_vrbo_access_token',
+                'reservation_endpoint' => 'https://partner.api.expediapartnercentral.com/v1/vrbo/reservations/%s',
+                'collection_endpoint' => 'https://partner.api.expediapartnercentral.com/v1/vrbo/reservations',
+                'reservation_param' => 'itineraryId',
+            ),
+            'booking_com' => array(
+                'label' => __('Booking.com', 'guest-management-system'),
+                'option' => 'gms_booking_access_token',
+                'reservation_endpoint' => 'https://distribution-xml.booking.com/json/reservations/%s',
+                'collection_endpoint' => 'https://distribution-xml.booking.com/json/reservations',
+                'reservation_param' => 'reservation_id',
+            ),
+        );
+
+        /**
+         * Filter the OTA reservation configuration map.
+         *
+         * @param array $defaults Default configuration values.
+         */
+        return apply_filters('gms_ota_reservation_config', $defaults);
+    }
+
+    /**
+     * Synchronize a single reservation with its OTA platform.
+     *
+     * @param array $reservation Reservation data array.
+     * @param array $args        Optional additional arguments for the request.
+     *
+     * @return array Result information.
+     */
+    public function sync_reservation($reservation, $args = array()) {
+        if (!is_array($reservation) || empty($reservation)) {
+            return array(
+                'success' => false,
+                'action' => 'error',
+                'errors' => array(__('Reservation data missing. Unable to sync with OTA platform.', 'guest-management-system')),
+            );
+        }
+
+        $platform_key = $this->normalize_platform($reservation['platform'] ?? '');
+        if ($platform_key === '') {
+            return array(
+                'success' => false,
+                'action' => 'error',
+                'errors' => array(__('Assign a platform before syncing reservation details.', 'guest-management-system')),
+            );
+        }
+
+        $booking_reference = $this->normalize_booking_reference($reservation['booking_reference'] ?? '');
+        if ($booking_reference === '') {
+            return array(
+                'success' => false,
+                'action' => 'error',
+                'errors' => array(__('Add the platform booking reference to sync reservation details.', 'guest-management-system')),
+            );
+        }
+
+        $platform_config = $this->resolve_platform($platform_key);
+        if (empty($platform_config)) {
+            return array(
+                'success' => false,
+                'action' => 'error',
+                'errors' => array(__('Unknown OTA platform configuration.', 'guest-management-system')),
+            );
+        }
+
+        if ($platform_config['token'] === '') {
+            return array(
+                'success' => false,
+                'action' => 'error',
+                'errors' => array(
+                    sprintf(
+                        /* translators: %s: OTA platform label */
+                        __('Add credentials for %s before syncing reservation details.', 'guest-management-system'),
+                        $platform_config['label']
+                    )
+                ),
+            );
+        }
+
+        $request = $this->request_single_reservation($platform_key, $platform_config, $booking_reference, $args);
+        if (empty($request['success'])) {
+            return array(
+                'success' => false,
+                'action' => 'error',
+                'errors' => isset($request['errors']) ? (array) $request['errors'] : array(__('Unable to reach the OTA reservation endpoint.', 'guest-management-system')),
+            );
+        }
+
+        $mapped = $this->map_payload_to_reservation($platform_key, $request['payload'], $booking_reference, $reservation);
+        $upsert = $this->upsert_reservation($platform_key, $platform_config['label'], $mapped, $reservation);
+
+        $result = array(
+            'success' => !empty($upsert['success']),
+            'action' => $upsert['action'] ?? '',
+            'message' => $upsert['message'] ?? '',
+            'updated_fields' => $upsert['updated_fields'] ?? array(),
+            'reservation_id' => $upsert['reservation_id'] ?? ($reservation['id'] ?? 0),
+            'booking_reference' => $upsert['booking_reference'] ?? $booking_reference,
+            'errors' => isset($upsert['errors']) ? (array) $upsert['errors'] : array(),
+        );
+
+        if ($result['success'] && $result['message'] === '') {
+            $result['message'] = sprintf(
+                /* translators: %s: OTA platform label */
+                __('Reservation synced from %s.', 'guest-management-system'),
+                $platform_config['label']
+            );
+        }
+
+        if (!$result['success'] && empty($result['errors'])) {
+            $result['errors'][] = sprintf(
+                /* translators: %s: OTA platform label */
+                __('Unable to sync reservation from %s.', 'guest-management-system'),
+                $platform_config['label']
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Import reservations from a specific platform.
+     *
+     * @param string $platform Platform key or label.
+     * @param array  $args     Optional request arguments.
+     *
+     * @return array Summary information.
+     */
+    public function import_platform_reservations($platform, $args = array()) {
+        $platform_key = $this->normalize_platform($platform);
+
+        if ($platform_key === 'all' || $platform_key === '') {
+            return $this->import_all_platforms($args);
+        }
+
+        $platform_config = $this->resolve_platform($platform_key);
+        if (empty($platform_config)) {
+            return array(
+                'success' => false,
+                'created' => 0,
+                'updated' => 0,
+                'synced' => 0,
+                'skipped' => 0,
+                'errors' => array(__('Unknown OTA platform configuration.', 'guest-management-system')),
+                'messages' => array(),
+            );
+        }
+
+        if ($platform_config['token'] === '') {
+            return array(
+                'success' => false,
+                'created' => 0,
+                'updated' => 0,
+                'synced' => 0,
+                'skipped' => 0,
+                'errors' => array(
+                    sprintf(
+                        /* translators: %s: OTA platform label */
+                        __('Add credentials for %s before importing reservations.', 'guest-management-system'),
+                        $platform_config['label']
+                    )
+                ),
+                'messages' => array(),
+            );
+        }
+
+        $request = $this->request_reservation_collection($platform_key, $platform_config, $args);
+        if (empty($request['success'])) {
+            return array(
+                'success' => false,
+                'created' => 0,
+                'updated' => 0,
+                'synced' => 0,
+                'skipped' => 0,
+                'errors' => isset($request['errors']) ? (array) $request['errors'] : array(__('Unable to import reservations from the OTA.', 'guest-management-system')),
+                'messages' => array(),
+            );
+        }
+
+        $reservations = isset($request['reservations']) && is_array($request['reservations']) ? $request['reservations'] : array();
+
+        $summary = array(
+            'success' => false,
+            'created' => 0,
+            'updated' => 0,
+            'synced' => 0,
+            'skipped' => 0,
+            'errors' => array(),
+            'messages' => array(),
+        );
+
+        if (empty($reservations)) {
+            $summary['success'] = true;
+            $summary['messages'][] = sprintf(
+                /* translators: %s: OTA platform label */
+                __('No reservations were returned from %s.', 'guest-management-system'),
+                $platform_config['label']
+            );
+            return $summary;
+        }
+
+        foreach ($reservations as $reservation_payload) {
+            $mapped = $this->map_payload_to_reservation($platform_key, $reservation_payload);
+            $booking_reference = $this->normalize_booking_reference($mapped['booking_reference'] ?? '');
+
+            if ($booking_reference === '') {
+                $summary['skipped']++;
+                $summary['errors'][] = sprintf(
+                    /* translators: %s: OTA platform label */
+                    __('Skipped a %s reservation without a booking reference.', 'guest-management-system'),
+                    $platform_config['label']
+                );
+                continue;
+            }
+
+            $existing = GMS_Database::getReservationByPlatformReference($platform_key, $booking_reference);
+            $upsert = $this->upsert_reservation($platform_key, $platform_config['label'], $mapped, $existing);
+
+            if (empty($upsert['success'])) {
+                $summary['errors'] = array_merge($summary['errors'], isset($upsert['errors']) ? (array) $upsert['errors'] : array());
+                continue;
+            }
+
+            $summary['success'] = true;
+            $summary['messages'][] = sprintf(
+                '%1$s – %2$s (%3$s)',
+                $platform_config['label'],
+                $upsert['message'] ?? __('Reservation synced.', 'guest-management-system'),
+                $upsert['booking_reference'] ?? $booking_reference
+            );
+
+            switch ($upsert['action'] ?? '') {
+                case 'created':
+                    $summary['created']++;
+                    break;
+                case 'updated':
+                    $summary['updated']++;
+                    break;
+                default:
+                    $summary['synced']++;
+                    break;
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Import reservations from all configured platforms.
+     *
+     * @param array $args Optional request arguments.
+     *
+     * @return array Combined summary information.
+     */
+    public function import_all_platforms($args = array()) {
+        $combined = array(
+            'success' => false,
+            'created' => 0,
+            'updated' => 0,
+            'synced' => 0,
+            'skipped' => 0,
+            'errors' => array(),
+            'messages' => array(),
+        );
+
+        $config = $this->get_platform_config();
+
+        foreach ($config as $platform_key => $platform_settings) {
+            $result = $this->import_platform_reservations($platform_key, $args);
+
+            $combined['created'] += intval($result['created'] ?? 0);
+            $combined['updated'] += intval($result['updated'] ?? 0);
+            $combined['synced'] += intval($result['synced'] ?? 0);
+            $combined['skipped'] += intval($result['skipped'] ?? 0);
+            $combined['messages'] = array_merge($combined['messages'], isset($result['messages']) ? (array) $result['messages'] : array());
+            $combined['errors'] = array_merge($combined['errors'], isset($result['errors']) ? (array) $result['errors'] : array());
+            $combined['success'] = $combined['success'] || !empty($result['success']);
+        }
+
+        return $combined;
+    }
+
+    /**
+     * Normalize a platform identifier.
+     *
+     * @param string $platform Platform identifier.
+     *
+     * @return string Normalized key.
+     */
+    private function normalize_platform($platform) {
+        $platform = strtolower(trim((string) $platform));
+
+        if ($platform === '') {
+            return '';
+        }
+
+        $platform = str_replace(array('.', ' ', '-'), '_', $platform);
+
+        if ($platform === 'bookingcom') {
+            $platform = 'booking_com';
+        }
+
+        return $platform;
+    }
+
+    /**
+     * Resolve platform configuration and credentials.
+     *
+     * @param string $platform_key Normalized platform key.
+     *
+     * @return array
+     */
+    private function resolve_platform($platform_key) {
+        $platform_key = $this->normalize_platform($platform_key);
+
+        if ($platform_key === '') {
+            return array();
+        }
+
+        $config = $this->get_platform_config();
+
+        if (!isset($config[$platform_key])) {
+            return array();
+        }
+
+        $platform = $config[$platform_key];
+        $option_key = isset($platform['option']) ? $platform['option'] : '';
+        $platform['key'] = $platform_key;
+        $platform['token'] = $option_key !== '' ? trim((string) get_option($option_key, '')) : '';
+
+        return $platform;
+    }
+    /**
+     * Perform a single reservation request against the OTA platform.
+     *
+     * @param string $platform_key      Platform key.
+     * @param array  $platform_config   Platform configuration.
+     * @param string $booking_reference Booking reference identifier.
+     * @param array  $args              Optional request arguments.
+     *
+     * @return array
+     */
+    private function request_single_reservation($platform_key, $platform_config, $booking_reference, $args = array()) {
+        $endpoint = $this->build_single_endpoint($platform_key, $platform_config, $booking_reference, $args);
+
+        if ($endpoint === '') {
+            return array(
+                'success' => false,
+                'errors' => array(__('OTA reservation endpoint not configured.', 'guest-management-system')),
+            );
+        }
+
+        $request_args = $this->build_request_args($platform_config['token'], $platform_key, 'single', array(
+            'booking_reference' => $booking_reference,
+            'config' => $platform_config,
+        ));
+
+        $response = wp_remote_get($endpoint, $request_args);
+
+        if (is_wp_error($response)) {
+            return array(
+                'success' => false,
+                'errors' => array($response->get_error_message()),
+            );
+        }
+
+        $status_code = wp_remote_retrieve_response_code($response);
+        $body = wp_remote_retrieve_body($response);
+        $decoded = $body !== '' ? json_decode($body, true) : array();
+
+        if ($status_code < 200 || $status_code >= 300) {
+            return array(
+                'success' => false,
+                'errors' => array(
+                    sprintf(
+                        /* translators: 1: HTTP status code, 2: OTA platform label */
+                        __('OTA request returned HTTP %1$s for %2$s.', 'guest-management-system'),
+                        $status_code,
+                        $platform_config['label']
+                    )
+                ),
+            );
+        }
+
+        $payload = $this->extract_single_payload($decoded);
+        if (empty($payload)) {
+            return array(
+                'success' => false,
+                'errors' => array(__('No reservation data was returned from the OTA.', 'guest-management-system')),
+            );
+        }
+
+        /**
+         * Filter the OTA reservation payload before mapping.
+         *
+         * @param array  $payload      Reservation payload.
+         * @param string $platform_key Normalized platform key.
+         * @param string $context      Request context.
+         * @param array  $raw_response Raw decoded response.
+         */
+        $payload = apply_filters('gms_ota_reservation_payload', $payload, $platform_key, 'single', $decoded);
+
+        return array(
+            'success' => true,
+            'payload' => $payload,
+            'status_code' => $status_code,
+        );
+    }
+
+    /**
+     * Perform a reservation collection request.
+     *
+     * @param string $platform_key    Platform key.
+     * @param array  $platform_config Platform configuration.
+     * @param array  $args            Request arguments.
+     *
+     * @return array
+     */
+    private function request_reservation_collection($platform_key, $platform_config, $args = array()) {
+        $endpoint = $this->build_collection_endpoint($platform_key, $platform_config, $args);
+
+        if ($endpoint === '') {
+            return array(
+                'success' => false,
+                'errors' => array(__('OTA collection endpoint not configured.', 'guest-management-system')),
+            );
+        }
+
+        $request_args = $this->build_request_args($platform_config['token'], $platform_key, 'collection', array(
+            'config' => $platform_config,
+            'args' => $args,
+        ));
+
+        $response = wp_remote_get($endpoint, $request_args);
+
+        if (is_wp_error($response)) {
+            return array(
+                'success' => false,
+                'errors' => array($response->get_error_message()),
+            );
+        }
+
+        $status_code = wp_remote_retrieve_response_code($response);
+        $body = wp_remote_retrieve_body($response);
+        $decoded = $body !== '' ? json_decode($body, true) : array();
+
+        if ($status_code < 200 || $status_code >= 300) {
+            return array(
+                'success' => false,
+                'errors' => array(
+                    sprintf(
+                        /* translators: 1: HTTP status code, 2: OTA platform label */
+                        __('OTA request returned HTTP %1$s for %2$s.', 'guest-management-system'),
+                        $status_code,
+                        $platform_config['label']
+                    )
+                ),
+            );
+        }
+
+        $payload = $this->extract_collection_payload($decoded);
+
+        /**
+         * Filter the OTA reservation collection payload.
+         *
+         * @param array  $payload      Collection payload.
+         * @param string $platform_key Platform key.
+         * @param string $context      Request context.
+         * @param array  $raw_response Raw decoded response.
+         */
+        $payload = apply_filters('gms_ota_reservation_payload', $payload, $platform_key, 'collection', $decoded);
+
+        if (!is_array($payload)) {
+            $payload = array();
+        }
+
+        return array(
+            'success' => true,
+            'reservations' => $payload,
+            'status_code' => $status_code,
+        );
+    }
+
+    /**
+     * Build request arguments for the OTA HTTP requests.
+     *
+     * @param string $token        Access token.
+     * @param string $platform_key Platform key.
+     * @param string $context      Request context.
+     * @param array  $extra        Extra arguments for filters.
+     *
+     * @return array
+     */
+    private function build_request_args($token, $platform_key, $context, $extra = array()) {
+        $headers = array(
+            'Accept' => 'application/json',
+        );
+
+        if ($token !== '') {
+            $headers['Authorization'] = 'Bearer ' . $token;
+        }
+
+        $args = array(
+            'headers' => $headers,
+            'timeout' => 20,
+        );
+
+        /**
+         * Filter the OTA reservation request arguments.
+         *
+         * @param array  $args         Request arguments.
+         * @param string $platform_key Platform key.
+         * @param string $context      Request context.
+         * @param array  $extra        Extra data for filters.
+         */
+        return apply_filters('gms_ota_reservation_request_args', $args, $platform_key, $context, $extra);
+    }
+
+    /**
+     * Build the endpoint URL for a single reservation request.
+     *
+     * @param string $platform_key      Platform key.
+     * @param array  $platform_config   Platform configuration.
+     * @param string $booking_reference Booking reference.
+     * @param array  $args              Additional arguments.
+     *
+     * @return string
+     */
+    private function build_single_endpoint($platform_key, $platform_config, $booking_reference, $args = array()) {
+        $endpoint = isset($platform_config['reservation_endpoint']) ? trim((string) $platform_config['reservation_endpoint']) : '';
+
+        if ($endpoint === '') {
+            return '';
+        }
+
+        if (strpos($endpoint, '%s') !== false) {
+            $endpoint = sprintf($endpoint, rawurlencode($booking_reference));
+        } else {
+            $param = isset($platform_config['reservation_param']) ? $platform_config['reservation_param'] : 'booking_reference';
+            $endpoint = add_query_arg($param, rawurlencode($booking_reference), $endpoint);
+        }
+
+        /**
+         * Filter the OTA reservation endpoint.
+         *
+         * @param string $endpoint     Endpoint URL.
+         * @param string $platform_key Platform key.
+         * @param string $context      Request context.
+         * @param array  $args         Additional arguments.
+         */
+        return apply_filters('gms_ota_reservation_endpoint', $endpoint, $platform_key, 'single', $args);
+    }
+
+    /**
+     * Build the endpoint URL for reservation collection requests.
+     *
+     * @param string $platform_key    Platform key.
+     * @param array  $platform_config Platform configuration.
+     * @param array  $args            Request arguments.
+     *
+     * @return string
+     */
+    private function build_collection_endpoint($platform_key, $platform_config, $args = array()) {
+        $endpoint = isset($platform_config['collection_endpoint']) && $platform_config['collection_endpoint'] !== ''
+            ? trim((string) $platform_config['collection_endpoint'])
+            : trim((string) ($platform_config['reservation_endpoint'] ?? ''));
+
+        if ($endpoint === '') {
+            return '';
+        }
+
+        $query_args = array();
+
+        if (!empty($args['since'])) {
+            $since_timestamp = strtotime($args['since'] . ' 00:00:00');
+            if ($since_timestamp !== false) {
+                $query_args['updated_since'] = gmdate('c', $since_timestamp);
+            }
+        }
+
+        if (!empty($args['limit'])) {
+            $query_args['limit'] = max(1, min(absint($args['limit']), 200));
+        }
+
+        if (!empty($args['status'])) {
+            $query_args['status'] = sanitize_key($args['status']);
+        }
+
+        if (!empty($query_args)) {
+            $endpoint = add_query_arg($query_args, $endpoint);
+        }
+
+        /**
+         * Filter the OTA collection endpoint.
+         *
+         * @param string $endpoint     Endpoint URL.
+         * @param string $platform_key Platform key.
+         * @param string $context      Request context.
+         * @param array  $args         Additional arguments.
+         */
+        return apply_filters('gms_ota_reservation_endpoint', $endpoint, $platform_key, 'collection', $args);
+    }
+
+    /**
+     * Extract a reservation payload from the OTA response.
+     *
+     * @param mixed $decoded Decoded response.
+     *
+     * @return array
+     */
+    private function extract_single_payload($decoded) {
+        if (!is_array($decoded)) {
+            return array();
+        }
+
+        if (isset($decoded['reservation']) && is_array($decoded['reservation'])) {
+            return $decoded['reservation'];
+        }
+
+        if (isset($decoded['data'])) {
+            if (isset($decoded['data']['reservation']) && is_array($decoded['data']['reservation'])) {
+                return $decoded['data']['reservation'];
+            }
+
+            if (is_array($decoded['data']) && !empty($decoded['data'])) {
+                $first = reset($decoded['data']);
+                if (is_array($first)) {
+                    return $first;
+                }
+            }
+        }
+
+        if (isset($decoded['result']) && is_array($decoded['result'])) {
+            if (isset($decoded['result']['reservation']) && is_array($decoded['result']['reservation'])) {
+                return $decoded['result']['reservation'];
+            }
+        }
+
+        if (isset($decoded[0]) && is_array($decoded[0])) {
+            return $decoded[0];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Extract reservation collection payloads.
+     *
+     * @param mixed $decoded Decoded response.
+     *
+     * @return array
+     */
+    private function extract_collection_payload($decoded) {
+        if (!is_array($decoded)) {
+            return array();
+        }
+
+        if (isset($decoded['reservations']) && is_array($decoded['reservations'])) {
+            return $decoded['reservations'];
+        }
+
+        if (isset($decoded['data']) && is_array($decoded['data'])) {
+            return $decoded['data'];
+        }
+
+        if (isset($decoded['result']) && is_array($decoded['result'])) {
+            if (isset($decoded['result']['reservations']) && is_array($decoded['result']['reservations'])) {
+                return $decoded['result']['reservations'];
+            }
+        }
+
+        if (isset($decoded[0]) && is_array($decoded[0])) {
+            return $decoded;
+        }
+
+        return array();
+    }
+    /**
+     * Map OTA payload into reservation fields.
+     *
+     * @param string $platform_key       Platform key.
+     * @param array  $payload            Reservation payload.
+     * @param string $fallback_reference Optional fallback booking reference.
+     * @param array  $existing           Existing reservation data.
+     *
+     * @return array
+     */
+    private function map_payload_to_reservation($platform_key, $payload, $fallback_reference = '', $existing = array()) {
+        if (!is_array($payload)) {
+            $payload = array();
+        }
+
+        $reference = $this->normalize_booking_reference($this->read_value($payload, array(
+            array('confirmation_code'),
+            array('booking_reference'),
+            array('bookingReference'),
+            array('reservation_id'),
+            array('reservationId'),
+            array('code'),
+            array('id'),
+        ), $fallback_reference));
+
+        $guest_first = $this->sanitize_string($this->read_value($payload, array(
+            array('guest', 'first_name'),
+            array('guest', 'firstName'),
+            array('traveler', 'firstName'),
+            array('customer', 'first_name'),
+        )));
+        $guest_last = $this->sanitize_string($this->read_value($payload, array(
+            array('guest', 'last_name'),
+            array('guest', 'lastName'),
+            array('traveler', 'lastName'),
+            array('customer', 'last_name'),
+        )));
+        $guest_full = $this->sanitize_string($this->read_value($payload, array(
+            array('guest', 'full_name'),
+            array('guest', 'name'),
+            array('traveler', 'name'),
+            array('customer', 'full_name'),
+        )));
+
+        $guest_name = trim($guest_first . ' ' . $guest_last);
+        if ($guest_name === '') {
+            $guest_name = $guest_full;
+        }
+
+        $guest_email = sanitize_email($this->read_value($payload, array(
+            array('guest', 'email'),
+            array('traveler', 'email'),
+            array('customer', 'email'),
+            array('contact', 'email'),
+        )));
+
+        $guest_phone_raw = $this->read_value($payload, array(
+            array('guest', 'phone'),
+            array('guest', 'phone_number'),
+            array('traveler', 'phone'),
+            array('customer', 'phone'),
+            array('contact', 'phone'),
+        ));
+
+        if (function_exists('gms_sanitize_phone')) {
+            $guest_phone = gms_sanitize_phone($guest_phone_raw);
+        } else {
+            $guest_phone = preg_replace('/[^0-9+\-()\s]/', '', (string) $guest_phone_raw);
+        }
+
+        $property_name = $this->sanitize_string($this->read_value($payload, array(
+            array('listing', 'name'),
+            array('property', 'name'),
+            array('unit', 'name'),
+            array('hotel', 'name'),
+        )));
+        $property_id = $this->sanitize_string($this->read_value($payload, array(
+            array('listing', 'id'),
+            array('property', 'id'),
+            array('unit', 'id'),
+            array('hotel', 'id'),
+            array('unit_id'),
+        )));
+
+        $checkin = $this->maybe_normalize_datetime($this->read_value($payload, array(
+            array('check_in'),
+            array('check_in_date'),
+            array('arrival_date'),
+            array('arrival'),
+            array('stay', 'check_in'),
+            array('stay', 'start'),
+        )));
+        $checkout = $this->maybe_normalize_datetime($this->read_value($payload, array(
+            array('check_out'),
+            array('check_out_date'),
+            array('departure_date'),
+            array('departure'),
+            array('stay', 'check_out'),
+            array('stay', 'end'),
+        )));
+
+        $status_raw = $this->sanitize_string($this->read_value($payload, array(
+            array('status'),
+            array('reservation_status'),
+            array('booking_status'),
+        )));
+        $status = $this->normalize_status($platform_key, $status_raw);
+
+        $door_code = GMS_Database::sanitizeDoorCode($this->read_value($payload, array(
+            array('door_code'),
+            array('doorCode'),
+            array('access', 'code'),
+            array('access', 'pin'),
+            array('keyless_entry', 'code'),
+        )));
+
+        $fields = array(
+            'guest_name' => $guest_name,
+            'guest_email' => $guest_email,
+            'guest_phone' => $guest_phone,
+            'property_name' => $property_name,
+            'property_id' => $property_id,
+            'door_code' => $door_code,
+            'checkin_date' => $checkin,
+            'checkout_date' => $checkout,
+            'status' => $status,
+        );
+
+        $snapshot = array(
+            'booking_reference' => $reference,
+            'guest_name' => $guest_name,
+            'guest_email' => $guest_email,
+            'guest_phone' => $guest_phone,
+            'property_name' => $property_name,
+            'property_id' => $property_id,
+            'checkin_date' => $checkin,
+            'checkout_date' => $checkout,
+            'status' => $status,
+            'status_raw' => $status_raw,
+        );
+
+        if ($door_code !== '') {
+            $snapshot['door_code'] = $door_code;
+        }
+
+        $mapped = array(
+            'booking_reference' => $reference,
+            'fields' => $fields,
+            'snapshot' => $snapshot,
+        );
+
+        /**
+         * Filter the mapped OTA reservation data before persistence.
+         *
+         * @param array  $mapped       Mapped reservation array.
+         * @param string $platform_key Platform key.
+         * @param array  $payload      Raw OTA payload.
+         * @param array  $existing     Existing reservation data.
+         */
+        return apply_filters('gms_ota_reservation_mapped_data', $mapped, $platform_key, $payload, $existing);
+    }
+
+    /**
+     * Persist reservation data to the database.
+     *
+     * @param string $platform_key        Platform key.
+     * @param string $platform_label      Platform label.
+     * @param array  $mapped              Mapped reservation data.
+     * @param array  $existing_reservation Existing reservation data.
+     *
+     * @return array
+     */
+    private function upsert_reservation($platform_key, $platform_label, $mapped, $existing_reservation = null) {
+        $platform_label = $this->sanitize_string($platform_label);
+
+        $booking_reference = $this->normalize_booking_reference($mapped['booking_reference'] ?? '');
+        $fields = isset($mapped['fields']) && is_array($mapped['fields']) ? $mapped['fields'] : array();
+        $snapshot = isset($mapped['snapshot']) && is_array($mapped['snapshot']) ? $mapped['snapshot'] : array();
+
+        if ($booking_reference === '') {
+            return array(
+                'success' => false,
+                'action' => 'skipped',
+                'errors' => array(__('Reservation is missing a booking reference and was skipped.', 'guest-management-system')),
+            );
+        }
+
+        if (empty($existing_reservation)) {
+            $existing_reservation = GMS_Database::getReservationByPlatformReference($platform_key, $booking_reference);
+        }
+
+        $existing_webhook = isset($existing_reservation['webhook_data']) && is_array($existing_reservation['webhook_data'])
+            ? $existing_reservation['webhook_data']
+            : array();
+
+        if (empty($existing_reservation)) {
+            $create_data = array(
+                'guest_name' => $fields['guest_name'] ?? '',
+                'guest_email' => $fields['guest_email'] ?? '',
+                'guest_phone' => $fields['guest_phone'] ?? '',
+                'property_name' => $fields['property_name'] ?? '',
+                'property_id' => $fields['property_id'] ?? '',
+                'door_code' => $fields['door_code'] ?? '',
+                'checkin_date' => $fields['checkin_date'] ?? '',
+                'checkout_date' => $fields['checkout_date'] ?? '',
+                'status' => $fields['status'] ?? 'pending',
+                'booking_reference' => $booking_reference,
+                'platform' => $platform_key,
+                'webhook_data' => $this->merge_webhook_snapshot($existing_webhook, $platform_key, $snapshot, array()),
+            );
+
+            $created_id = GMS_Database::createReservation($create_data);
+
+            if (!$created_id) {
+                return array(
+                    'success' => false,
+                    'action' => 'error',
+                    'errors' => array(__('Unable to save the OTA reservation.', 'guest-management-system')),
+                );
+            }
+
+            $updated_fields = array();
+            foreach ($fields as $field_key => $field_value) {
+                if ($field_value !== '') {
+                    $updated_fields[] = $field_key;
+                }
+            }
+
+            if (!empty($fields['status'])) {
+                $updated_fields[] = 'status';
+            }
+
+            return array(
+                'success' => true,
+                'action' => 'created',
+                'reservation_id' => $created_id,
+                'booking_reference' => $booking_reference,
+                'updated_fields' => array_values(array_unique($updated_fields)),
+                'message' => sprintf(
+                    /* translators: %s: OTA platform label */
+                    __('Reservation imported from %s.', 'guest-management-system'),
+                    $platform_label
+                ),
+            );
+        }
+
+        $reservation_id = intval($existing_reservation['id']);
+
+        $update_data = array('platform' => $platform_key);
+        $updated_fields = array();
+
+        foreach ($fields as $field_key => $field_value) {
+            if ($field_key === 'status') {
+                if ($field_value === '') {
+                    continue;
+                }
+                $update_data[$field_key] = $field_value;
+                if (isset($existing_reservation[$field_key]) && $existing_reservation[$field_key] !== $field_value) {
+                    $updated_fields[] = $field_key;
+                }
+                continue;
+            }
+
+            if ($field_value === '' || $field_value === null) {
+                continue;
+            }
+
+            $update_data[$field_key] = $field_value;
+
+            if (isset($existing_reservation[$field_key]) && $existing_reservation[$field_key] !== $field_value) {
+                $updated_fields[] = $field_key;
+            }
+        }
+
+        $synced_fields = array();
+        foreach ($update_data as $key => $value) {
+            if ($key === 'webhook_data' || $key === 'platform') {
+                continue;
+            }
+            $synced_fields[] = $key;
+        }
+
+        $update_data['webhook_data'] = $this->merge_webhook_snapshot(
+            $existing_webhook,
+            $platform_key,
+            $snapshot,
+            array('synced_fields' => $synced_fields)
+        );
+
+        $result = GMS_Database::updateReservation($reservation_id, $update_data);
+
+        if ($result === false) {
+            return array(
+                'success' => false,
+                'action' => 'error',
+                'errors' => array(__('Unable to update the reservation with OTA details.', 'guest-management-system')),
+            );
+        }
+
+        $updated_count = count(array_unique($updated_fields));
+        $message = $updated_count > 0
+            ? sprintf(
+                _n('Updated %1$d field from %2$s.', 'Updated %1$d fields from %2$s.', $updated_count, 'guest-management-system'),
+                $updated_count,
+                $platform_label
+            )
+            : sprintf(
+                __('%s reservation is already up to date.', 'guest-management-system'),
+                $platform_label
+            );
+
+        return array(
+            'success' => true,
+            'action' => $updated_count > 0 ? 'updated' : 'synced',
+            'reservation_id' => $reservation_id,
+            'booking_reference' => $booking_reference,
+            'updated_fields' => array_values(array_unique($updated_fields)),
+            'message' => $message,
+        );
+    }
+
+    /**
+     * Merge OTA snapshot data into the webhook payload store.
+     *
+     * @param array $existing_data Existing webhook data.
+     * @param string $platform_key Platform key.
+     * @param array $snapshot      Snapshot data.
+     * @param array $additional    Additional metadata.
+     *
+     * @return array
+     */
+    private function merge_webhook_snapshot($existing_data, $platform_key, $snapshot, $additional = array()) {
+        if (!is_array($existing_data)) {
+            $existing_data = array();
+        }
+
+        if (!isset($existing_data['ota_sync']) || !is_array($existing_data['ota_sync'])) {
+            $existing_data['ota_sync'] = array();
+        }
+
+        if (isset($additional['synced_fields'])) {
+            $additional['synced_fields'] = array_values(array_filter(array_map('sanitize_key', (array) $additional['synced_fields'])));
+        }
+
+        $entry = array(
+            'last_synced' => current_time('mysql'),
+            'snapshot' => $this->sanitize_snapshot($snapshot),
+        );
+
+        if (!empty($additional)) {
+            $entry = array_merge($entry, $additional);
+        }
+
+        $existing_data['ota_sync'][$platform_key] = $entry;
+
+        return $existing_data;
+    }
+
+    /**
+     * Sanitize nested snapshot data before storage.
+     *
+     * @param array $snapshot Snapshot data.
+     *
+     * @return array
+     */
+    private function sanitize_snapshot($snapshot) {
+        if (!is_array($snapshot)) {
+            return array();
+        }
+
+        $sanitized = array();
+
+        foreach ($snapshot as $key => $value) {
+            $clean_key = sanitize_key($key);
+            if (is_array($value)) {
+                $sanitized[$clean_key] = $this->sanitize_snapshot($value);
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $sanitized[$clean_key] = wp_strip_all_tags((string) $value);
+            }
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Normalize a booking reference value.
+     *
+     * @param string $reference Booking reference.
+     *
+     * @return string
+     */
+    private function normalize_booking_reference($reference) {
+        $reference = trim((string) $reference);
+        return sanitize_text_field($reference);
+    }
+
+    /**
+     * Sanitize a string value.
+     *
+     * @param mixed $value Value to sanitize.
+     *
+     * @return string
+     */
+    private function sanitize_string($value) {
+        if (is_array($value) || is_object($value)) {
+            return '';
+        }
+
+        return trim(wp_strip_all_tags((string) $value));
+    }
+
+    /**
+     * Normalize date values for storage.
+     *
+     * @param string $value Raw date value.
+     *
+     * @return string
+     */
+    private function maybe_normalize_datetime($value) {
+        $value = trim((string) $value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $timestamp = strtotime($value);
+        if ($timestamp === false) {
+            return '';
+        }
+
+        if (function_exists('wp_date') && function_exists('wp_timezone')) {
+            return wp_date('Y-m-d H:i:s', $timestamp, wp_timezone());
+        }
+
+        return date('Y-m-d H:i:s', $timestamp);
+    }
+
+    /**
+     * Read a value from nested payload paths.
+     *
+     * @param array $payload Payload array.
+     * @param array $paths   Paths to inspect.
+     * @param mixed $default Default value when not found.
+     *
+     * @return mixed
+     */
+    private function read_value($payload, $paths, $default = '') {
+        foreach ($paths as $path) {
+            $value = $payload;
+            $found = true;
+
+            foreach ((array) $path as $segment) {
+                if (is_array($value) && array_key_exists($segment, $value)) {
+                    $value = $value[$segment];
+                } else {
+                    $found = false;
+                    break;
+                }
+            }
+
+            if ($found) {
+                return $value;
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * Normalize OTA-specific status values to internal states.
+     *
+     * @param string $platform_key Platform key.
+     * @param string $status       Raw status.
+     *
+     * @return string
+     */
+    private function normalize_status($platform_key, $status) {
+        $status = strtolower(trim((string) $status));
+
+        if ($status === '') {
+            return 'pending';
+        }
+
+        $maps = array(
+            'airbnb' => array(
+                'accepted' => 'confirmed',
+                'confirmed' => 'confirmed',
+                'canceled' => 'cancelled',
+                'cancelled' => 'cancelled',
+                'declined' => 'cancelled',
+                'pending' => 'pending',
+            ),
+            'vrbo' => array(
+                'booked' => 'confirmed',
+                'confirmed' => 'confirmed',
+                'cancelled' => 'cancelled',
+                'canceled' => 'cancelled',
+                'pending' => 'pending',
+            ),
+            'booking_com' => array(
+                'confirmed' => 'confirmed',
+                'ok' => 'confirmed',
+                'cancelled' => 'cancelled',
+                'canceled' => 'cancelled',
+                'pending' => 'pending',
+            ),
+        );
+
+        if (isset($maps[$platform_key][$status])) {
+            $normalized = $maps[$platform_key][$status];
+        } else {
+            $normalized = $status;
+        }
+
+        if ($normalized === 'canceled') {
+            $normalized = 'cancelled';
+        }
+
+        if (!in_array($normalized, array('pending', 'confirmed', 'cancelled', 'completed', 'approved'), true)) {
+            $normalized = 'pending';
+        }
+
+        /**
+         * Filter the normalized OTA status.
+         *
+         * @param string $normalized   Normalized status.
+         * @param string $status       Raw status value.
+         * @param string $platform_key Platform key.
+         */
+        return apply_filters('gms_ota_reservation_status', $normalized, $status, $platform_key);
+    }
+}

--- a/includes/class-sms-handler.php
+++ b/includes/class-sms-handler.php
@@ -686,7 +686,10 @@ class GMS_SMS_Handler implements GMS_Messaging_Channel_Interface {
             'recipient' => $phone_validation['sanitized'],
             'message' => $message,
             'status' => $result ? 'sent' : 'failed',
-            'response_data' => array('result' => $result)
+            'response_data' => array(
+                'result' => $result,
+                'context' => 'welcome_sequence',
+            ),
         ));
 
         return $result;
@@ -742,7 +745,10 @@ class GMS_SMS_Handler implements GMS_Messaging_Channel_Interface {
             'recipient' => $phone_validation['sanitized'],
             'message' => $message,
             'status' => $result ? 'sent' : 'failed',
-            'response_data' => array('result' => $result)
+            'response_data' => array(
+                'result' => $result,
+                'context' => 'portal_link_sequence',
+            ),
         ));
 
         return $result;
@@ -794,7 +800,11 @@ class GMS_SMS_Handler implements GMS_Messaging_Channel_Interface {
             'recipient' => $phone_validation['sanitized'],
             'message' => $message,
             'status' => $result ? 'sent' : 'failed',
-            'response_data' => array('result' => $result, 'door_code' => $sanitized_code)
+            'response_data' => array(
+                'result' => $result,
+                'context' => 'door_code_sequence',
+                'door_code' => $sanitized_code,
+            ),
         ));
 
         return $result;


### PR DESCRIPTION
## Summary
- add a reservation workflow toolbar with quick navigation and contextual step status highlights
- introduce a contact directory panel and communication feed so admins can manage guest details and activity from one screen
- refactor timeline rendering and admin scripting to support reusable activity lists and quick copy actions for sensitive data

## Testing
- `php -l includes/class-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68e3ecf060048324aae33ed08b1b83fa