### PR TITLE
Prevent AJAX hijack on reservation edit page

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -426,16 +426,21 @@
         });
 
         $(document).on('submit', '.gms-reservation-form', function(e) {
-            e.preventDefault();
-
             var $form = $(this);
+            var $editorRow = $form.closest('tr.gms-reservation-editor');
+
+            if (!$editorRow.length) {
+                return;
+            }
+
             var reservationId = parseInt($form.data('reservation-id'), 10);
 
             if (!reservationId) {
                 return;
             }
 
-            var $editorRow = $form.closest('tr.gms-reservation-editor');
+            e.preventDefault();
+
             var $row = $editorRow.prev('tr');
             var $submitButton = $form.find('button[type="submit"]');
             var originalSubmitText = $submitButton.text();


### PR DESCRIPTION
## Summary
- ensure the admin inline-edit JavaScript only intercepts reservation forms rendered inside the list table editor rows
- allow the standalone reservation edit form to perform a normal POST so updates persist

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5b4b27ffc8324bbc702eb6866cbf6